### PR TITLE
Port microkelvin to `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,7 @@ license = "MPL-2.0"
 readme = "README.md"
 
 [dependencies]
-canonical = { version = "0.3", features = ["host"] }
-canonical_derive = "0.3"
-
-[dev-dependencies]
-canonical_host = "0.3"
+canonical = { version = "0.4", features = ["host"] }
+canonical_derive = "0.4"
+canonical_host = "0.4"
+const-arrayvec = "0.2.1"

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -4,13 +4,15 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use std::marker::PhantomData;
-use std::ops::Deref;
+use core::marker::PhantomData;
+use core::ops::Deref;
 
 use canonical::Store;
 
 use crate::annotation::Annotated;
 use crate::compound::{Child, Compound};
+
+use const_arrayvec::ArrayVec;
 
 pub struct Level<'a, C, S>
 where
@@ -74,21 +76,23 @@ where
     Owned(C, PhantomData<S>),
 }
 
-pub struct PartialBranch<'a, C, S>(Levels<'a, C, S>)
+pub struct PartialBranch<'a, C, S, const N: usize>(Levels<'a, C, S, N>)
 where
     C: Clone;
 
-pub struct Levels<'a, C, S>(Vec<Level<'a, C, S>>)
+pub struct Levels<'a, C, S, const N: usize>(ArrayVec<Level<'a, C, S>, N>)
 where
     C: Clone;
 
-impl<'a, C, S> Levels<'a, C, S>
+impl<'a, C, S, const N: usize> Levels<'a, C, S, N>
 where
     C: Compound<S>,
     S: Store,
 {
     pub fn new(node: &'a C) -> Self {
-        Levels(vec![Level::new_borrowed(node)])
+        let mut levels: ArrayVec<Level<'a, C, S>, N> = ArrayVec::new();
+        levels.push(Level::new_borrowed(node));
+        Levels(levels)
     }
 
     pub fn depth(&self) -> usize {
@@ -131,7 +135,7 @@ where
     }
 }
 
-impl<'a, C, S> PartialBranch<'a, C, S>
+impl<'a, C, S, const N: usize> PartialBranch<'a, C, S, N>
 where
     C: Compound<S>,
     S: Store,
@@ -206,7 +210,7 @@ where
     Into(&'a Annotated<C, S>),
 }
 
-impl<'a, C, S> Branch<'a, C, S>
+impl<'a, C, S, const N: usize> Branch<'a, C, S, N>
 where
     C: Compound<S>,
     S: Store,
@@ -231,11 +235,11 @@ where
     }
 }
 
-pub struct Branch<'a, C, S>(PartialBranch<'a, C, S>)
+pub struct Branch<'a, C, S, const N: usize>(PartialBranch<'a, C, S, N>)
 where
     C: Clone;
 
-impl<'a, C, S> Deref for Branch<'a, C, S>
+impl<'a, C, S, const N: usize> Deref for Branch<'a, C, S, N>
 where
     C: Compound<S>,
     S: Store,

--- a/src/branch_mut.rs
+++ b/src/branch_mut.rs
@@ -4,14 +4,16 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use std::marker::PhantomData;
-use std::mem;
-use std::ops::{Deref, DerefMut};
+use core::marker::PhantomData;
+use core::mem;
+use core::ops::{Deref, DerefMut};
 
 use canonical::Store;
 
 use crate::annotation::Annotated;
 use crate::compound::{Child, ChildMut, Compound};
+
+use const_arrayvec::ArrayVec;
 
 pub enum WalkMut<'a, C, S>
 where
@@ -105,23 +107,25 @@ where
     }
 }
 
-pub struct PartialBranchMut<'a, C, S>(LevelsMut<'a, C, S>)
+pub struct PartialBranchMut<'a, C, S, const N: usize>(LevelsMut<'a, C, S, N>)
 where
     C: Compound<S>,
     S: Store;
 
-pub struct LevelsMut<'a, C, S>(Vec<LevelMut<'a, C, S>>)
+pub struct LevelsMut<'a, C, S, const N: usize>(ArrayVec<LevelMut<'a, C, S>, N>)
 where
     C: Compound<S>,
     S: Store;
 
-impl<'a, C, S> LevelsMut<'a, C, S>
+impl<'a, C, S, const N: usize> LevelsMut<'a, C, S, N>
 where
     C: Compound<S>,
     S: Store,
 {
     pub fn new(first: LevelMut<'a, C, S>) -> Self {
-        LevelsMut(vec![first])
+        let mut levels: ArrayVec<LevelMut<'a, C, S>, N> = ArrayVec::new();
+        levels.push(first);
+        LevelsMut(levels)
     }
 
     pub fn depth(&self) -> usize {
@@ -182,7 +186,7 @@ where
     }
 }
 
-impl<'a, C, S> PartialBranchMut<'a, C, S>
+impl<'a, C, S, const N: usize> PartialBranchMut<'a, C, S, N>
 where
     C: Compound<S>,
     S: Store,
@@ -260,7 +264,7 @@ where
     }
 }
 
-impl<'a, C, S> Drop for PartialBranchMut<'a, C, S>
+impl<'a, C, S, const N: usize> Drop for PartialBranchMut<'a, C, S, N>
 where
     C: Compound<S>,
     S: Store,
@@ -271,7 +275,7 @@ where
     }
 }
 
-impl<'a, C, S> BranchMut<'a, C, S>
+impl<'a, C, S, const N: usize> BranchMut<'a, C, S, N>
 where
     C: Compound<S>,
     S: Store,
@@ -296,12 +300,12 @@ where
     }
 }
 
-pub struct BranchMut<'a, C, S>(PartialBranchMut<'a, C, S>)
+pub struct BranchMut<'a, C, S, const N: usize>(PartialBranchMut<'a, C, S, N>)
 where
     C: Compound<S>,
     S: Store;
 
-impl<'a, C, S> Deref for BranchMut<'a, C, S>
+impl<'a, C, S, const N: usize> Deref for BranchMut<'a, C, S, N>
 where
     C: Compound<S>,
     S: Store,
@@ -313,7 +317,7 @@ where
     }
 }
 
-impl<'a, C, S> DerefMut for BranchMut<'a, C, S>
+impl<'a, C, S, const N: usize> DerefMut for BranchMut<'a, C, S, N>
 where
     C: Compound<S>,
     S: Store,

--- a/src/compound.rs
+++ b/src/compound.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use std::borrow::Borrow;
+use core::borrow::Borrow;
 
 use canonical::{Canon, Store};
 
@@ -57,19 +57,22 @@ where
     }
 }
 
-pub trait Nth<'a, S>
+pub trait Nth<'a, S, const N: usize>
 where
     Self: Compound<S> + Sized,
     S: Store,
 {
-    fn nth(&'a self, n: u64) -> Result<Option<Branch<'a, Self, S>>, S::Error>;
+    fn nth(
+        &'a self,
+        n: u64,
+    ) -> Result<Option<Branch<'a, Self, S, N>>, S::Error>;
     fn nth_mut(
         &'a mut self,
         n: u64,
-    ) -> Result<Option<BranchMut<'a, Self, S>>, S::Error>;
+    ) -> Result<Option<BranchMut<'a, Self, S, N>>, S::Error>;
 }
 
-impl<'a, C, S> Nth<'a, S> for C
+impl<'a, C, S, const N: usize> Nth<'a, S, N> for C
 where
     C: Compound<S>,
     C::Annotation: Borrow<Cardinality>,
@@ -78,7 +81,7 @@ where
     fn nth(
         &'a self,
         mut index: u64,
-    ) -> Result<Option<Branch<'a, Self, S>>, S::Error> {
+    ) -> Result<Option<Branch<'a, Self, S, N>>, S::Error> {
         Branch::walk(self, |f| match f {
             Walk::Leaf(l) => {
                 if index == 0 {
@@ -103,7 +106,7 @@ where
     fn nth_mut(
         &'a mut self,
         mut index: u64,
-    ) -> Result<Option<BranchMut<'a, Self, S>>, S::Error> {
+    ) -> Result<Option<BranchMut<'a, Self, S, N>>, S::Error> {
         BranchMut::walk(self, |f| match f {
             WalkMut::Leaf(l) => {
                 if index == 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+#![no_std]
+#![feature(min_const_generics)]
+
 mod annotation;
 mod branch;
 mod branch_mut;


### PR DESCRIPTION
- Use `Cow` from `canon` instead of `std`
- Use `ArrayVec` from `const-arrayvec` instead of `Vec`
- port `std::` to `core::` equivalents