### PR TITLE
Associative annotation as a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ const-arrayvec = "0.2"
 
 [dev-dependencies]
 canonical_host = "0.4"
+
+[features]
+default = []
+associative = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,9 @@ mod branch;
 mod branch_mut;
 mod compound;
 
-pub use annotation::{Annotated, Annotation, Associative, Cardinality, Max};
+#[cfg(feature = "associative")]
+pub use annotation::Associative;
+pub use annotation::{Annotated, Annotation, Cardinality, Max};
 pub use branch::Branch;
 pub use branch_mut::BranchMut;
-pub use compound::{Child, ChildMut, Compound, Nth};
+pub use compound::{Child, ChildIterator, ChildMut, Compound, Nth};


### PR DESCRIPTION
The blanket implementations of the associative trait are currently buggy
(check #19)

Its usage have been moved to a non-default feature