### PR TITLE
Cardinality reference implements Into<u64>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 30-10-20
+### Added
+- Cardinality reference implements Into<u64>
+
 ## [0.5.0] - 28-10-20
 ### Changed
 - Associative annotation as a feature

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microkelvin"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 keywords = ["datastructures"]

--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -223,6 +223,12 @@ where
 #[derive(Canon, PartialEq, Debug, Clone)]
 pub struct Cardinality(pub(crate) u64);
 
+impl Into<u64> for &Cardinality {
+    fn into(self) -> u64 {
+        self.0
+    }
+}
+
 #[cfg(feature = "associative")]
 impl<L> Associative<L> for Cardinality {
     fn identity() -> Self {


### PR DESCRIPTION
We need the ability to extract the internal number of a cardinality annotation in order to get the full count of leaves of a tree