### PR TITLE
Canonical update to support hosted-only calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 06-11-20
+### Changed
+- Canonical update to support hosted-only calls
+- Unused associative feature removed
+
 ## [0.5.1] - 30-10-20
 ### Added
 - Cardinality reference implements Into<u64>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microkelvin"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 keywords = ["datastructures"]
@@ -9,13 +9,9 @@ license = "MPL-2.0"
 readme = "README.md"
 
 [dependencies]
-canonical = { version = "0.4", features = ["host"] }
+canonical = "0.4"
 canonical_derive = "0.4"
 const-arrayvec = "0.2"
 
 [dev-dependencies]
 canonical_host = "0.4"
-
-[features]
-default = []
-associative = []

--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -8,7 +8,7 @@ use core::borrow::Borrow;
 use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};
 
-use canonical::{Canon, Cow, Repr, Sink, Source, Store, ValMut};
+use canonical::{Canon, Repr, Sink, Source, Store, Val, ValMut};
 use canonical_derive::Canon;
 
 use crate::compound::{Child, Compound};
@@ -29,50 +29,6 @@ where
     fn from_node(node: &C) -> Self;
 }
 
-/// Helper trait for associative cases, automatically implements
-/// `Annotation` for the type implemented for.
-#[cfg(feature = "associative")]
-pub trait Associative<L> {
-    /// The empty annotation.
-    fn identity() -> Self;
-
-    /// Creates annotation from a leaf.
-    fn from_leaf(leaf: &L) -> Self;
-
-    /// Operaion to create an annotation by combining two of them
-    fn op(self, b: &Self) -> Self;
-}
-
-#[cfg(feature = "associative")]
-impl<A, C, S> Annotation<C, S> for A
-where
-    A: Associative<C::Leaf>,
-    C: Compound<S, Annotation = A>,
-    S: Store,
-{
-    fn identity() -> Self {
-        A::identity()
-    }
-
-    fn from_leaf(leaf: &C::Leaf) -> Self {
-        A::from_leaf(leaf)
-    }
-
-    fn from_node(node: &C) -> Self {
-        let mut annotation = Self::identity();
-        for i in 0.. {
-            match node.child(i) {
-                Child::Leaf(l) => {
-                    annotation = annotation.op(&Self::from_leaf(l))
-                }
-                Child::Node(n) => annotation = annotation.op(n.annotation()),
-                Child::EndOfNode => return annotation,
-            };
-        }
-        unreachable!()
-    }
-}
-
 /// A reference o a value carrying an annotation
 pub struct AnnRef<'a, C, S>
 where
@@ -80,7 +36,7 @@ where
     S: Store,
 {
     annotation: &'a C::Annotation,
-    compound: Cow<'a, C>,
+    compound: Val<'a, C>,
     _marker: PhantomData<S>,
 }
 
@@ -112,7 +68,7 @@ where
     S: Store,
 {
     annotation: &'a mut C::Annotation,
-    compound: ValMut<'a, C>,
+    compound: ValMut<'a, C, S>,
     _marker: PhantomData<S>,
 }
 
@@ -229,23 +185,6 @@ impl Into<u64> for &Cardinality {
     }
 }
 
-#[cfg(feature = "associative")]
-impl<L> Associative<L> for Cardinality {
-    fn identity() -> Self {
-        Cardinality(0)
-    }
-
-    fn from_leaf(_leaf: &L) -> Self {
-        Cardinality(1)
-    }
-
-    fn op(mut self, b: &Self) -> Self {
-        self.0 += b.0;
-        self
-    }
-}
-
-#[cfg(not(feature = "associative"))]
 impl<C, S> Annotation<C, S> for Cardinality
 where
     C: Compound<S>,
@@ -283,36 +222,6 @@ pub enum Max<K> {
     Maximum(K),
 }
 
-#[cfg(feature = "associative")]
-impl<K, L> Associative<L> for Max<K>
-where
-    K: Ord + Clone,
-    L: Borrow<K>,
-{
-    fn identity() -> Self {
-        Max::NegativeInfinity
-    }
-
-    fn from_leaf(leaf: &L) -> Self {
-        Max::Maximum(leaf.borrow().clone())
-    }
-
-    fn op(self, b: &Self) -> Self {
-        match (self, b) {
-            (a @ Max::Maximum(_), Max::NegativeInfinity) => a,
-            (Max::NegativeInfinity, b) => b.clone(),
-            (Max::Maximum(ref a), Max::Maximum(b)) => {
-                if a > b {
-                    Max::Maximum(a.clone())
-                } else {
-                    Max::Maximum(b.clone())
-                }
-            }
-        }
-    }
-}
-
-#[cfg(not(feature = "associative"))]
 impl<C, S, K> Annotation<C, S> for Max<K>
 where
     C: Compound<S>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,6 @@ mod branch;
 mod branch_mut;
 mod compound;
 
-#[cfg(feature = "associative")]
-pub use annotation::Associative;
 pub use annotation::{Annotated, Annotation, Cardinality, Max};
 pub use branch::{Branch, Level, Step, Walk};
 pub use branch_mut::{BranchMut, LevelMut, StepMut, WalkMut};


### PR DESCRIPTION
Any implementation of microkelvin should be compatible with hosted-only
environments

Also, the associative function is superseeded by the annotation;
therefore, never used