### PR TITLE
Annotation for kelvin map implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.3] - 16-11-20
+### Changed
+- Use PartialOrd with K in Max<K>
+
 ## [0.5.2] - 06-11-20
 ### Changed
 - Canonical update to support hosted-only calls

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microkelvin"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 keywords = ["datastructures"]

--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -226,7 +226,7 @@ impl<C, S, K> Annotation<C, S> for Max<K>
 where
     C: Compound<S>,
     S: Store,
-    K: Ord + Clone,
+    K: PartialOrd + Clone,
     C::Leaf: Borrow<K>,
     C::Annotation: Borrow<K>,
 {


### PR DESCRIPTION
Kelvin map requires the ordering of maximum related to its key because it is a binary search tree.

All the operations of a binary search tree depends on checks over the maximum value of a sub-tree and a provided key.

This way, we need to extend that `Max` to implement `PartialOrd` relative to itself and to its own key