### PR TITLE
Annotation of Max<K> should req `Borrow<Max<K>>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4] - 03-12-20
+### Changed
+- Annotation impl of Max<K> should require `Borrow<Max<K>>`
+
 ## [0.5.3] - 16-11-20
 ### Changed
 - Use PartialOrd with K in Max<K>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microkelvin"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 keywords = ["datastructures"]


### PR DESCRIPTION
The current `Borrow<K>` is too generic and will conflict with other
implementations, e.g. Cardinality