### PR TITLE
`Max<K>` should implement `PartialOrd<K>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.5] - 03-12-20
+### Changed
+- `Max<K>` should implement `PartialOrd<K>`
+
 ## [0.5.4] - 03-12-20
 ### Changed
 - Annotation impl of Max<K> should require `Borrow<Max<K>>`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microkelvin"
-version = "0.5.4"
+version = "0.5.5"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 keywords = ["datastructures"]

--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -255,6 +255,30 @@ where
     }
 }
 
+impl<K> PartialEq<K> for Max<K>
+where
+    K: PartialEq,
+{
+    fn eq(&self, k: &K) -> bool {
+        match self {
+            Max::NegativeInfinity => false,
+            Max::Maximum(k_p) => k_p == k,
+        }
+    }
+}
+
+impl<K> PartialOrd<K> for Max<K>
+where
+    K: PartialOrd + Eq,
+{
+    fn partial_cmp(&self, k: &K) -> Option<Ordering> {
+        match self {
+            Max::NegativeInfinity => Some(Ordering::Less),
+            Max::Maximum(k_p) => k_p.partial_cmp(k),
+        }
+    }
+}
+
 impl<C, S, K> Annotation<C, S> for Max<K>
 where
     C: Compound<S>,
@@ -442,8 +466,10 @@ mod tests {
 
     #[test]
     fn ordering() {
+        const N_INF: Max<i32> = Max::NegativeInfinity;
+
         assert!(Max::Maximum(0) > Max::Maximum(-1));
         assert!(Max::Maximum(-1234) > Max::NegativeInfinity);
-        assert!(Max::NegativeInfinity < Max::Maximum(-1234));
+        assert!(N_INF < Max::Maximum(-1234));
     }
 }


### PR DESCRIPTION
A given key `K` should be comparable to an existing instance of `Max<K>`
so its easier to implement any compound operation with keys and max.