### PR TITLE
Add public export of Walker

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,4 +31,4 @@ pub use annotations::{
 pub use branch::Branch;
 pub use branch_mut::BranchMut;
 pub use compound::{Child, ChildMut, Compound, IterChild, MutableLeaves};
-pub use walk::{First, Step, Walk};
+pub use walk::{First, Step, Walk, Walker};

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -53,11 +53,13 @@ where
     }
 }
 
+/// The trait used to construct a `Branch` or to iterate through a tree.
 pub trait Walker<C, A>
 where
     C: Compound<A>,
     A: Combine<C, A>,
 {
+    /// Walk the tree node, returning the appropriate `Step`
     fn walk(&mut self, walk: Walk<C, A>) -> Step;
 }
 


### PR DESCRIPTION
`Walker` was mistakenly not previously 