### PR TITLE
Add public export of Walker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2021-04-27
+
+### Added
+
+- Add public export of `walk::Walker` in lib.rs
+
 ## [0.7.0] - 2021-04-21
 
 ### Added
@@ -124,7 +130,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial
 
-[Unreleased]: https://github.com/dusk-network/microkelvin/compare/v-0.7.0...HEAD
+[Unreleased]: https://github.com/dusk-network/microkelvin/compare/v-0.7.1...HEAD
+[0.7.1]: https://github.com/dusk-network/microkelvin/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/dusk-network/microkelvin/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/dusk-network/microkelvin/compare/v0.5.8...v0.6.0
 [0.5.8]: https://github.com/dusk-network/microkelvin/compare/v0.5.7...v0.5.8

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microkelvin"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 keywords = ["datastructures"]
@@ -14,3 +14,4 @@ canonical_derive = "0.6"
 
 [dev-dependencies]
 rand = "0.8.3"
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,4 +31,4 @@ pub use annotations::{
 pub use branch::Branch;
 pub use branch_mut::BranchMut;
 pub use compound::{Child, ChildMut, Compound, IterChild, MutableLeaves};
-pub use walk::{First, Step, Walk};
+pub use walk::{First, Step, Walk, Walker};

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -53,11 +53,13 @@ where
     }
 }
 
+/// The trait used to construct a `Branch` or to iterate through a tree.
 pub trait Walker<C, A>
 where
     C: Compound<A>,
     A: Combine<C, A>,
 {
+    /// Walks the node selecting a leaf or a node, aborting or proceeding
     fn walk(&mut self, walk: Walk<C, A>) -> Step;
 }
 


### PR DESCRIPTION
The `Walker` trait was mistakenly not exported in 0.7.0