### PR TITLE
Release 0.8.0

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --all-features
 
   fmt:
     name: Rustfmt
@@ -41,8 +42,6 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2020-10-25
-          override: true
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Change the name of `BranchMutMappedMut` to `MappedBranchMut`
+
+### Removed
+- Remove `path` from branch traversal, case now covered by `walk`
+
+## [0.7.2] - 2021-06-01
+
+### Added
+- Add `IntoIterator` to `MappedBranch` and `BranchMutMappedMut`
+- Add support for non-mutably dereferencing mutable mapped branches
+
 ## [0.7.1] - 2021-04-27
 
 ### Added
@@ -130,7 +142,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial
 
+<<<<<<< HEAD
 [Unreleased]: https://github.com/dusk-network/microkelvin/compare/v-0.7.1...HEAD
+=======
+[Unreleased]: https://github.com/dusk-network/microkelvin/compare/v-0.7.2...HEAD
+[0.7.2]: https://github.com/dusk-network/microkelvin/compare/v0.7.1...v0.7.2
+>>>>>>> Add public export of Walker
 [0.7.1]: https://github.com/dusk-network/microkelvin/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/dusk-network/microkelvin/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/dusk-network/microkelvin/compare/v0.5.8...v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.0] - 2021-06-18
+
+### Added
+- Add feature `persistance`
+- Add `DiskBackend` to persist datastructures to disk
+- Add `Persistance` to interact with the persistance layer
+- Add `IntoIterator` to `MappedBranch` and `BranchMutMappedMut`
+- Add support for non-mutably dereferencing mutable mapped branches
 
 ### Changed
 - Change the name of `BranchMutMappedMut` to `MappedBranchMut`
 
 ### Removed
 - Remove `path` from branch traversal, case now covered by `walk`
-
-## [0.7.2] - 2021-06-01
-
-### Added
-- Add `IntoIterator` to `MappedBranch` and `BranchMutMappedMut`
-- Add support for non-mutably dereferencing mutable mapped branches
 
 ## [0.7.1] - 2021-04-27
 
@@ -142,12 +143,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial
 
-<<<<<<< HEAD
-[Unreleased]: https://github.com/dusk-network/microkelvin/compare/v-0.7.1...HEAD
-=======
-[Unreleased]: https://github.com/dusk-network/microkelvin/compare/v-0.7.2...HEAD
-[0.7.2]: https://github.com/dusk-network/microkelvin/compare/v0.7.1...v0.7.2
->>>>>>> Add public export of Walker
+[Unreleased]: https://github.com/dusk-network/microkelvin/compare/v-0.8.0...HEAD
+[0.8.0]: https://github.com/dusk-network/microkelvin/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/dusk-network/microkelvin/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/dusk-network/microkelvin/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/dusk-network/microkelvin/compare/v0.5.8...v0.6.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microkelvin"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 keywords = ["datastructures"]
@@ -9,9 +9,18 @@ license = "MPL-2.0"
 readme = "README.md"
 
 [dependencies]
-canonical = "0.6"
-canonical_derive = "0.6"
+appendix = { version = "0.2.0", optional = true }
+parking_lot = { version = "0.11.1", optional = true }
+lazy_static = { version = "1.4.0", optional = true }
+canonical = "0.6.3"
+canonical_derive = "0.6.0"
+arbitrary = { version = "1.0.1", features = ["derive"] }
 
 [dev-dependencies]
 rand = "0.8.3"
+canonical_fuzz = "0.6.2"
+tempfile = { version = "3.2.0" }
+
+[features]
+persistance = ["appendix", "parking_lot", "lazy_static"]
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2021-06-06

--- a/src/annotations/cardinality.rs
+++ b/src/annotations/cardinality.rs
@@ -8,13 +8,13 @@
 /// i.e. the amount of elements in a collection
 use core::borrow::Borrow;
 
-use canonical::CanonError;
+use canonical::{Canon, CanonError};
 use canonical_derive::Canon;
 
 use crate::annotations::{Annotation, Combine};
 use crate::branch::Branch;
 use crate::branch_mut::BranchMut;
-use crate::compound::{Child, Compound, MutableLeaves};
+use crate::compound::{AnnoIter, Child, Compound, MutableLeaves};
 use crate::walk::{Step, Walk, Walker};
 
 /// The cardinality of a compound collection
@@ -39,19 +39,16 @@ impl<L> Annotation<L> for Cardinality {
     }
 }
 
-impl<C, A> Combine<C, A> for Cardinality
+impl<A> Combine<A> for Cardinality
 where
-    C: Compound<A>,
-    A: Annotation<C::Leaf> + Borrow<Self>,
+    A: Borrow<Self> + Canon,
 {
-    fn combine(node: &C) -> Self {
-        let mut sum = 0;
-        for child in node.children() {
-            let ann = &*child.annotation();
-            let card = ann.borrow();
-            sum += card.0
-        }
-        Cardinality(sum)
+    fn combine<C>(iter: AnnoIter<C, A>) -> Self
+    where
+        C: Compound<A>,
+        A: Annotation<C::Leaf>,
+    {
+        Cardinality(iter.fold(0, |sum, ann| sum + (*ann).borrow().0))
     }
 }
 
@@ -61,7 +58,7 @@ pub struct Offset(u64);
 impl<C, A> Walker<C, A> for Offset
 where
     C: Compound<A>,
-    A: Combine<C, A> + Borrow<Cardinality>,
+    A: Annotation<C::Leaf> + Borrow<Cardinality>,
 {
     fn walk(&mut self, walk: Walk<C, A>) -> Step {
         for i in 0.. {
@@ -74,7 +71,7 @@ where
                     }
                 }
                 Child::Node(node) => {
-                    let card: u64 = node.annotation().borrow().into();
+                    let card: u64 = (*node.annotation()).borrow().into();
 
                     if card <= self.0 {
                         self.0 -= card;
@@ -95,7 +92,7 @@ where
 pub trait Nth<'a, A>
 where
     Self: Compound<A>,
-    A: Combine<Self, A> + Borrow<Cardinality>,
+    A: Annotation<Self::Leaf> + Borrow<Cardinality>,
 {
     /// Construct a `Branch` pointing to the `nth` element, if any
     fn nth(&'a self, n: u64)
@@ -113,7 +110,7 @@ where
 impl<'a, C, A> Nth<'a, A> for C
 where
     C: Compound<A> + Clone,
-    A: Combine<C, A> + Borrow<Cardinality>,
+    A: Annotation<C::Leaf> + Borrow<Cardinality>,
 {
     fn nth(
         &'a self,
@@ -128,7 +125,6 @@ where
         ofs: u64,
     ) -> Result<Option<BranchMut<'a, Self, A>>, CanonError>
     where
-        A: Combine<Self, A>,
         C: MutableLeaves,
     {
         // Return the first mutable branch that satisfies the walk

--- a/src/annotations/max_key.rs
+++ b/src/annotations/max_key.rs
@@ -15,7 +15,7 @@ use canonical_derive::Canon;
 use crate::annotations::{Annotation, Combine};
 use crate::branch::Branch;
 use crate::branch_mut::BranchMut;
-use crate::compound::{Child, Compound, MutableLeaves};
+use crate::compound::{AnnoIter, Child, Compound, MutableLeaves};
 use crate::walk::{Step, Walk, Walker};
 
 /// The maximum value of a collection
@@ -81,32 +81,32 @@ where
 impl<K, L> Annotation<L> for MaxKey<K>
 where
     L: Keyed<K>,
-    K: Clone,
+    K: Clone + Ord + Canon,
 {
     fn from_leaf(leaf: &L) -> Self {
         MaxKey::Maximum(leaf.key().clone())
     }
 }
 
-impl<C, A, K> Combine<C, A> for MaxKey<K>
+impl<K, A> Combine<A> for MaxKey<K>
 where
-    C: Compound<A>,
-    C::Leaf: Keyed<K>,
-    A: Annotation<C::Leaf> + Borrow<Self>,
     K: Ord + Clone,
+    A: Borrow<Self> + Canon,
 {
-    fn combine(node: &C) -> Self {
-        let mut max = MaxKey::NegativeInfinity;
-
-        for child in node.children() {
-            let ann = &*child.annotation();
-            let m = ann.borrow();
-
+    fn combine<C>(iter: AnnoIter<C, A>) -> Self
+    where
+        C: Compound<A>,
+        A: Annotation<C::Leaf>,
+    {
+        iter.fold(MaxKey::NegativeInfinity, |max, ann| {
+            let m = (*ann).borrow();
+            // We only clone if neccesary
             if *m > max {
-                max = m.clone()
+                m.clone()
+            } else {
+                max
             }
-        }
-        max
+        })
     }
 }
 
@@ -123,7 +123,7 @@ impl<C, A, K> Walker<C, A> for FindMaxKey<K>
 where
     C: Compound<A>,
     C::Leaf: Keyed<K>,
-    A: Combine<C, A> + Borrow<MaxKey<K>>,
+    A: Annotation<C::Leaf> + Borrow<MaxKey<K>>,
     K: Ord + Clone + core::fmt::Debug,
 {
     fn walk(&mut self, walk: Walk<C, A>) -> Step {
@@ -141,9 +141,10 @@ where
                     }
                 }
                 Child::Node(n) => {
-                    let node_max = n.annotation().borrow().clone();
-                    if node_max > current_max {
-                        current_max = node_max;
+                    let ann = n.annotation();
+                    let node_max: &MaxKey<K> = (*ann).borrow();
+                    if node_max > &current_max {
+                        current_max = node_max.clone();
                         current_step = Step::Into(i);
                     }
                 }
@@ -161,7 +162,7 @@ pub trait GetMaxKey<'a, A, K>
 where
     Self: Compound<A>,
     Self::Leaf: Keyed<K>,
-    A: Combine<Self, A> + Borrow<MaxKey<K>> + Clone,
+    A: Annotation<Self::Leaf> + Borrow<MaxKey<K>>,
     K: Ord,
 {
     /// Construct a `Branch` pointing to the element with the largest key
@@ -172,7 +173,6 @@ where
         &'a mut self,
     ) -> Result<Option<BranchMut<'a, Self, A>>, CanonError>
     where
-        A: Combine<Self, A>,
         Self: MutableLeaves;
 }
 
@@ -180,7 +180,7 @@ impl<'a, C, A, K> GetMaxKey<'a, A, K> for C
 where
     C: Compound<A> + Clone,
     C::Leaf: Keyed<K>,
-    A: Combine<C, A> + Borrow<MaxKey<K>>,
+    A: Annotation<C::Leaf> + Borrow<MaxKey<K>>,
     K: Ord + Clone + core::fmt::Debug,
 {
     fn max_key(&'a self) -> Result<Option<Branch<'a, Self, A>>, CanonError> {
@@ -192,7 +192,6 @@ where
         &'a mut self,
     ) -> Result<Option<BranchMut<'a, Self, A>>, CanonError>
     where
-        A: Combine<Self, A>,
         C: MutableLeaves,
     {
         // Return the first mutable branch that satisfies the walk

--- a/src/annotations/unit.rs
+++ b/src/annotations/unit.rs
@@ -7,7 +7,7 @@
 #![allow(clippy::unused_unit)]
 
 use crate::annotations::{Annotation, Combine};
-use crate::compound::Compound;
+use crate::compound::AnnoIter;
 
 impl<L> Annotation<L> for () {
     fn from_leaf(_: &L) -> Self {
@@ -15,11 +15,8 @@ impl<L> Annotation<L> for () {
     }
 }
 
-impl<C, A> Combine<C, A> for ()
-where
-    C: Compound<A>,
-{
-    fn combine(_: &C) -> Self {
+impl<A> Combine<A> for () {
+    fn combine<C>(_: AnnoIter<C, A>) -> Self {
         ()
     }
 }

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -8,16 +8,17 @@ use core::ops::Deref;
 
 use alloc::vec::Vec;
 
-use canonical::CanonError;
+use canonical::{Canon, CanonError};
 
-use crate::annotations::{AnnRef, Combine};
+use crate::annotations::Annotation;
 use crate::compound::{Child, Compound};
+use crate::link::LinkCompound;
 use crate::walk::{AllLeaves, Step, Walk, Walker};
 
 #[derive(Debug)]
 enum LevelNode<'a, C, A> {
     Root(&'a C),
-    Val(AnnRef<'a, C, A>),
+    Val(LinkCompound<'a, C, A>),
 }
 
 #[derive(Debug)]
@@ -29,7 +30,7 @@ pub struct Level<'a, C, A> {
 impl<'a, C, A> Deref for Level<'a, C, A>
 where
     C: Compound<A>,
-    A: Combine<C, A>,
+    A: Canon,
 {
     type Target = C;
 
@@ -46,10 +47,10 @@ impl<'a, C, A> Level<'a, C, A> {
         }
     }
 
-    pub fn new_val(ann: AnnRef<'a, C, A>) -> Level<'a, C, A> {
+    pub fn new_val(link_compound: LinkCompound<'a, C, A>) -> Level<'a, C, A> {
         Level {
             offset: 0,
-            node: LevelNode::Val(ann),
+            node: LevelNode::Val(link_compound),
         }
     }
 
@@ -69,7 +70,7 @@ pub struct PartialBranch<'a, C, A>(Vec<Level<'a, C, A>>);
 impl<'a, C, A> Deref for LevelNode<'a, C, A>
 where
     C: Compound<A>,
-    A: Combine<C, A>,
+    A: Canon,
 {
     type Target = C;
 
@@ -84,7 +85,7 @@ where
 impl<'a, C, A> PartialBranch<'a, C, A>
 where
     C: Compound<A>,
-    A: Combine<C, A>,
+    A: Canon,
 {
     fn new(root: &'a C) -> Self {
         PartialBranch(vec![Level::new_root(root)])
@@ -102,7 +103,7 @@ where
         let top = self.top();
         let ofs = top.offset();
 
-        match top.child(ofs) {
+        match (**top).child(ofs) {
             Child::Leaf(l) => Some(l),
             _ => None,
         }
@@ -165,7 +166,8 @@ where
                     let ofs = top.offset();
                     let top_child = top.child(ofs);
                     if let Child::Node(n) = top_child {
-                        let level: Level<'_, C, A> = Level::new_val(n.val()?);
+                        let level: Level<'_, C, A> =
+                            Level::new_val(n.compound()?);
                         // Extend the lifetime of the Level.
                         //
                         // JUSTIFICATION
@@ -218,48 +220,12 @@ where
             }
         }
     }
-
-    fn path<P>(&mut self, mut path: P) -> Result<Option<()>, CanonError>
-    where
-        P: FnMut() -> usize,
-    {
-        let mut push = None;
-        loop {
-            if let Some(push) = push.take() {
-                self.0.push(push);
-            }
-
-            let ofs = path();
-            let top = self.top_mut();
-            *top.offset_mut() = ofs;
-
-            match top.child(ofs) {
-                Child::Leaf(_) => {
-                    return Ok(Some(()));
-                }
-                Child::Node(n) => {
-                    let level: Level<'_, C, A> = Level::new_val(n.val()?);
-                    // Extend the lifetime of the Level.
-                    // See comment in `Branch::walk` for justification.
-                    let extended: Level<'a, C, A> =
-                        unsafe { core::mem::transmute(level) };
-                    push = Some(extended);
-                }
-                Child::Empty => {
-                    return Ok(None);
-                }
-                Child::EndOfNode => {
-                    return Ok(None);
-                }
-            }
-        }
-    }
 }
 
 impl<'a, C, A> Branch<'a, C, A>
 where
     C: Compound<A>,
-    A: Combine<C, A>,
+    A: Canon,
 {
     /// Returns the depth of the branch
     pub fn depth(&self) -> usize {
@@ -295,15 +261,6 @@ where
         let mut partial = PartialBranch::new(root);
         Ok(partial.walk(&mut walker)?.map(|()| Branch(partial)))
     }
-
-    /// Construct a branch given a function returning child offsets
-    pub fn path<P>(root: &'a C, path: P) -> Result<Option<Self>, CanonError>
-    where
-        P: FnMut() -> usize,
-    {
-        let mut partial = PartialBranch::new(root);
-        Ok(partial.path(path)?.map(|()| Branch(partial)))
-    }
 }
 
 /// Reprents an immutable branch view into a collection.
@@ -316,7 +273,7 @@ pub struct Branch<'a, C, A>(PartialBranch<'a, C, A>);
 impl<'a, C, A> Deref for Branch<'a, C, A>
 where
     C: Compound<A>,
-    A: Combine<C, A>,
+    A: Canon,
 {
     type Target = C::Leaf;
 
@@ -328,7 +285,6 @@ where
 pub struct MappedBranch<'a, C, A, M>
 where
     C: Compound<A>,
-    A: Combine<C, A>,
 {
     inner: Branch<'a, C, A>,
     closure: for<'b> fn(&'b C::Leaf) -> &'b M,
@@ -338,7 +294,7 @@ impl<'a, C, A, M> Deref for MappedBranch<'a, C, A, M>
 where
     C: Compound<A>,
     C::Leaf: 'a,
-    A: Combine<C, A>,
+    A: Canon,
 {
     type Target = M;
 
@@ -357,7 +313,7 @@ pub enum BranchIterator<'a, C, A, W> {
 impl<'a, C, A> IntoIterator for Branch<'a, C, A>
 where
     C: Compound<A>,
-    A: Combine<C, A>,
+    A: Canon,
 {
     type Item = Result<&'a C::Leaf, CanonError>;
 
@@ -368,12 +324,11 @@ where
     }
 }
 
-// iterators
 impl<'a, C, A, W> Iterator for BranchIterator<'a, C, A, W>
 where
     C: Compound<A>,
-    A: Combine<C, A>,
     W: Walker<C, A>,
+    A: Canon,
 {
     type Item = Result<&'a C::Leaf, CanonError>;
 
@@ -407,6 +362,78 @@ where
             BranchIterator::Intermediate(branch, _) => {
                 let leaf: &C::Leaf = &*branch;
                 let leaf_extended: &'a C::Leaf =
+                    unsafe { core::mem::transmute(leaf) };
+                Some(Ok(leaf_extended))
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+pub enum MappedBranchIterator<'a, C, A, W, M>
+where
+    C: Compound<A>,
+    A: Annotation<C::Leaf>,
+{
+    Initial(MappedBranch<'a, C, A, M>, W),
+    Intermediate(MappedBranch<'a, C, A, M>, W),
+    Exhausted,
+}
+
+impl<'a, C, A, M> IntoIterator for MappedBranch<'a, C, A, M>
+where
+    C: Compound<A>,
+    A: Annotation<C::Leaf>,
+    M: 'a,
+{
+    type Item = Result<&'a M, CanonError>;
+
+    type IntoIter = MappedBranchIterator<'a, C, A, AllLeaves, M>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        MappedBranchIterator::Initial(self, AllLeaves)
+    }
+}
+
+impl<'a, C, A, W, M> Iterator for MappedBranchIterator<'a, C, A, W, M>
+where
+    C: Compound<A>,
+    A: Annotation<C::Leaf>,
+    W: Walker<C, A>,
+    M: 'a,
+{
+    type Item = Result<&'a M, CanonError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match core::mem::replace(self, Self::Exhausted) {
+            Self::Initial(branch, walker) => {
+                *self = Self::Intermediate(branch, walker);
+            }
+            Self::Intermediate(mut branch, mut walker) => {
+                branch.inner.0.advance();
+                // access partialbranch
+                match branch.inner.0.walk(&mut walker) {
+                    Ok(None) => {
+                        *self = Self::Exhausted;
+                        return None;
+                    }
+                    Ok(Some(..)) => {
+                        *self = Self::Intermediate(branch, walker);
+                    }
+                    Err(e) => {
+                        return Some(Err(e));
+                    }
+                }
+            }
+            Self::Exhausted => {
+                return None;
+            }
+        }
+
+        match self {
+            Self::Intermediate(branch, _) => {
+                let leaf: &M = &*branch;
+                let leaf_extended: &'a M =
                     unsafe { core::mem::transmute(leaf) };
                 Some(Ok(leaf_extended))
             }

--- a/src/branch_mut.rs
+++ b/src/branch_mut.rs
@@ -9,32 +9,25 @@ use core::ops::{Deref, DerefMut};
 
 use alloc::vec::Vec;
 
-use canonical::CanonError;
+use canonical::{Canon, CanonError};
 
-use crate::annotations::{AnnRefMut, Combine};
+use crate::annotations::Annotation;
 use crate::compound::{Child, ChildMut, Compound};
+use crate::link::LinkCompoundMut;
 use crate::walk::{AllLeaves, Step, Walk, Walker};
 
 #[derive(Debug)]
-enum LevelNodeMut<'a, C, A>
-where
-    C: Compound<A>,
-    A: Combine<C, A>,
-{
+enum LevelNodeMut<'a, C, A> {
     Root(&'a mut C),
-    Val(AnnRefMut<'a, C, A>),
+    Val(LinkCompoundMut<'a, C, A>),
 }
 
-impl<'a, C, A> Deref for LevelNodeMut<'a, C, A>
-where
-    C: Compound<A>,
-    A: Combine<C, A>,
-{
+impl<'a, C, A> Deref for LevelNodeMut<'a, C, A> {
     type Target = C;
 
     fn deref(&self) -> &Self::Target {
         match self {
-            LevelNodeMut::Root(target) => target,
+            LevelNodeMut::Root(root) => root,
             LevelNodeMut::Val(val) => &**val,
         }
     }
@@ -42,23 +35,18 @@ where
 
 impl<'a, C, A> DerefMut for LevelNodeMut<'a, C, A>
 where
-    C: Compound<A>,
-    A: Combine<C, A>,
+    C: Clone,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
             LevelNodeMut::Root(target) => target,
-            LevelNodeMut::Val(val) => &mut **val,
+            LevelNodeMut::Val(val) => &mut *val,
         }
     }
 }
 
 #[derive(Debug)]
-pub struct LevelMut<'a, C, A>
-where
-    C: Compound<A>,
-    A: Combine<C, A>,
-{
+pub struct LevelMut<'a, C, A> {
     offset: usize,
     node: LevelNodeMut<'a, C, A>,
 }
@@ -66,7 +54,6 @@ where
 impl<'a, C, A> Deref for LevelMut<'a, C, A>
 where
     C: Compound<A>,
-    A: Combine<C, A>,
 {
     type Target = C;
 
@@ -77,8 +64,7 @@ where
 
 impl<'a, C, A> DerefMut for LevelMut<'a, C, A>
 where
-    C: Compound<A>,
-    A: Combine<C, A>,
+    C: Compound<A> + Clone,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut *self.node
@@ -88,7 +74,6 @@ where
 impl<'a, C, A> LevelMut<'a, C, A>
 where
     C: Compound<A>,
-    A: Combine<C, A>,
 {
     fn new_root(root: &'a mut C) -> LevelMut<'a, C, A> {
         LevelMut {
@@ -97,10 +82,10 @@ where
         }
     }
 
-    fn new_val(ann: AnnRefMut<'a, C, A>) -> LevelMut<'a, C, A> {
+    fn new_val(link_compound: LinkCompoundMut<'a, C, A>) -> LevelMut<'a, C, A> {
         LevelMut {
             offset: 0,
-            node: LevelNodeMut::Val(ann),
+            node: LevelNodeMut::Val(link_compound),
         }
     }
 
@@ -114,15 +99,12 @@ where
     }
 }
 
-pub struct PartialBranchMut<'a, C, A>(Vec<LevelMut<'a, C, A>>)
-where
-    C: Compound<A>,
-    A: Combine<C, A>;
+pub struct PartialBranchMut<'a, C, A>(Vec<LevelMut<'a, C, A>>);
 
 impl<'a, C, A> PartialBranchMut<'a, C, A>
 where
     C: Compound<A>,
-    A: Combine<C, A>,
+    A: Canon,
 {
     fn new(root: &'a mut C) -> Self {
         PartialBranchMut(vec![LevelMut::new_root(root)])
@@ -150,7 +132,10 @@ where
         }
     }
 
-    fn leaf_mut(&mut self) -> Option<&mut C::Leaf> {
+    fn leaf_mut(&mut self) -> Option<&mut C::Leaf>
+    where
+        C: Clone,
+    {
         let top = self.top_mut();
         let ofs = top.offset();
 
@@ -176,6 +161,7 @@ where
     fn walk<W>(&mut self, walker: &mut W) -> Result<Option<()>, CanonError>
     where
         W: Walker<C, A>,
+        C: Canon,
     {
         enum State<C> {
             Init,
@@ -210,7 +196,7 @@ where
                     let top_child = top.child_mut(ofs);
                     if let ChildMut::Node(n) = top_child {
                         let level: LevelMut<'_, C, A> =
-                            LevelMut::new_val(n.val_mut()?);
+                            LevelMut::new_val(n.compound_mut()?);
 
                         // Extend the lifetime of the Level.
                         // See comment in `Branch::walk` for justification.
@@ -226,60 +212,12 @@ where
             }
         }
     }
-
-    fn path<P>(&mut self, mut path: P) -> Result<Option<()>, CanonError>
-    where
-        P: FnMut() -> usize,
-    {
-        let mut push = None;
-        loop {
-            if let Some(push) = push.take() {
-                self.0.push(push);
-            }
-
-            let ofs = path();
-            let top = self.top_mut();
-            *top.offset_mut() = ofs;
-
-            match top.child_mut(ofs) {
-                ChildMut::Leaf(_) => {
-                    return Ok(Some(()));
-                }
-                ChildMut::Node(n) => {
-                    let level: LevelMut<'_, C, A> =
-                        LevelMut::new_val(n.val_mut()?);
-                    // Extend the lifetime of the Level.
-                    // See comment in `Branch::walk` for justification.
-                    let extended: LevelMut<'a, C, A> =
-                        unsafe { core::mem::transmute(level) };
-                    push = Some(extended);
-                }
-                ChildMut::Empty => {
-                    return Ok(None);
-                }
-                ChildMut::EndOfNode => {
-                    return Ok(None);
-                }
-            }
-        }
-    }
-}
-
-impl<'a, C, A> Drop for BranchMut<'a, C, A>
-where
-    C: Compound<A>,
-    A: Combine<C, A>,
-{
-    fn drop(&mut self) {
-        // unwind when dropping
-        while self.0.pop().is_some() {}
-    }
 }
 
 impl<'a, C, A> BranchMut<'a, C, A>
 where
     C: Compound<A>,
-    A: Combine<C, A>,
+    A: Canon,
 {
     /// Returns the depth of the branch
     pub fn depth(&self) -> usize {
@@ -290,21 +228,9 @@ where
     /// Used in maps for example, to get easy access to the value of the KV-pair
     pub fn map_leaf<M>(
         self,
-        closure: for<'b> fn(&'b C::Leaf) -> &'b M,
-    ) -> BranchMutMapped<'a, C, A, M> {
-        BranchMutMapped {
-            inner: self,
-            closure,
-        }
-    }
-
-    /// Returns a branch that maps the leaf to a specific value.
-    /// Used in maps for example, to get easy access to the value of the KV-pair
-    pub fn map_leaf_mut<M>(
-        self,
         closure: for<'b> fn(&'b mut C::Leaf) -> &'b mut M,
-    ) -> BranchMutMappedMut<'a, C, A, M> {
-        BranchMutMappedMut {
+    ) -> MappedBranchMut<'a, C, A, M> {
+        MappedBranchMut {
             inner: self,
             closure,
         }
@@ -318,18 +244,10 @@ where
     ) -> Result<Option<Self>, CanonError>
     where
         W: Walker<C, A>,
+        C: Canon,
     {
         let mut partial = PartialBranchMut::new(root);
         Ok(partial.walk(&mut walker)?.map(|()| BranchMut(partial)))
-    }
-
-    /// Construct a branch given a function returning child offsets
-    pub fn path<P>(root: &'a mut C, path: P) -> Result<Option<Self>, CanonError>
-    where
-        P: FnMut() -> usize,
-    {
-        let mut partial = PartialBranchMut::new(root);
-        Ok(partial.path(path)?.map(|()| BranchMut(partial)))
     }
 }
 
@@ -341,15 +259,12 @@ where
 ///
 /// Branches are always guaranteed to point at a leaf, and can be dereferenced
 /// to the pointed-at leaf.
-pub struct BranchMut<'a, C, A>(PartialBranchMut<'a, C, A>)
-where
-    C: Compound<A>,
-    A: Combine<C, A>;
+pub struct BranchMut<'a, C, A>(PartialBranchMut<'a, C, A>);
 
 impl<'a, C, A> Deref for BranchMut<'a, C, A>
 where
     C: Compound<A>,
-    A: Combine<C, A>,
+    A: Canon,
 {
     type Target = C::Leaf;
 
@@ -360,8 +275,8 @@ where
 
 impl<'a, C, A> DerefMut for BranchMut<'a, C, A>
 where
-    C: Compound<A>,
-    A: Combine<C, A>,
+    C: Compound<A> + Clone,
+    A: Canon,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0.leaf_mut().expect("Invalid branch")
@@ -369,77 +284,56 @@ where
 }
 
 /// A `BranchMut` with a mapped leaf
-pub struct BranchMutMapped<'a, C, A, M>
+pub struct MappedBranchMut<'a, C, A, M>
 where
     C: Compound<A>,
-    A: Combine<C, A>,
-{
-    inner: BranchMut<'a, C, A>,
-    closure: for<'b> fn(&'b C::Leaf) -> &'b M,
-}
-
-impl<'a, C, A, M> Deref for BranchMutMapped<'a, C, A, M>
-where
-    C: Compound<A>,
-    A: Combine<C, A>,
-{
-    type Target = M;
-
-    fn deref(&self) -> &M {
-        (self.closure)(&*self.inner)
-    }
-}
-
-/// A `BranchMut` with a mutably mapped leaf
-pub struct BranchMutMappedMut<'a, C, A, M>
-where
-    C: Compound<A>,
-    A: Combine<C, A>,
 {
     inner: BranchMut<'a, C, A>,
     closure: for<'b> fn(&'b mut C::Leaf) -> &'b mut M,
 }
 
-impl<'a, C, A, M> Deref for BranchMutMappedMut<'a, C, A, M>
+impl<'a, C, A, M> Deref for MappedBranchMut<'a, C, A, M>
 where
-    C: Compound<A>,
-    A: Combine<C, A>,
+    C: Compound<A> + Clone,
+    A: Canon,
 {
     type Target = M;
 
     fn deref(&self) -> &M {
-        // FIXME, could we just transmute &self to &mut self here, since we're
-        // turning it back to a & reference again directly?
-
-        todo!()
+        // This is safe since we never use the mutable pointer as such, and
+        // convert it back to a shared reference as we return.
+        unsafe {
+            let transmuted: *mut Self = core::mem::transmute(self);
+            (self.closure)(&mut (*transmuted).inner)
+        }
     }
 }
 
-impl<'a, C, A, M> DerefMut for BranchMutMappedMut<'a, C, A, M>
+impl<'a, C, A, M> DerefMut for MappedBranchMut<'a, C, A, M>
 where
     C: Compound<A>,
-    A: Combine<C, A>,
+    A: Canon,
 {
     fn deref_mut(&mut self) -> &mut M {
         (self.closure)(&mut *self.inner)
     }
 }
 
+// iterators
+
 pub enum BranchMutIterator<'a, C, A, W>
 where
     C: Compound<A>,
-    A: Combine<C, A>,
 {
     Initial(BranchMut<'a, C, A>, W),
     Intermediate(BranchMut<'a, C, A>, W),
     Exhausted,
 }
 
-// iterators
 impl<'a, C, A> IntoIterator for BranchMut<'a, C, A>
 where
     C: Compound<A>,
-    A: Combine<C, A>,
+    A: Canon,
 {
     type Item = Result<&'a mut C::Leaf, CanonError>;
 
@@ -450,12 +344,11 @@ where
     }
 }
 
-// iterators
 impl<'a, C, A, W> Iterator for BranchMutIterator<'a, C, A, W>
 where
-    C: Compound<A>,
-    A: Combine<C, A>,
+    C: Compound<A> + Clone,
     W: Walker<C, A>,
+    A: Canon,
 {
     type Item = Result<&'a mut C::Leaf, CanonError>;
 
@@ -489,6 +382,78 @@ where
             BranchMutIterator::Intermediate(branch, _) => {
                 let leaf: &mut C::Leaf = &mut *branch;
                 let leaf_extended: &'a mut C::Leaf =
+                    unsafe { core::mem::transmute(leaf) };
+                Some(Ok(leaf_extended))
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+pub enum MappedBranchMutIterator<'a, C, A, W, M>
+where
+    C: Compound<A>,
+    A: Annotation<C::Leaf>,
+{
+    Initial(MappedBranchMut<'a, C, A, M>, W),
+    Intermediate(MappedBranchMut<'a, C, A, M>, W),
+    Exhausted,
+}
+
+impl<'a, C, A, M> IntoIterator for MappedBranchMut<'a, C, A, M>
+where
+    C: Compound<A> + Clone,
+    A: Annotation<C::Leaf>,
+    M: 'a,
+{
+    type Item = Result<&'a mut M, CanonError>;
+
+    type IntoIter = MappedBranchMutIterator<'a, C, A, AllLeaves, M>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        MappedBranchMutIterator::Initial(self, AllLeaves)
+    }
+}
+
+impl<'a, C, A, W, M> Iterator for MappedBranchMutIterator<'a, C, A, W, M>
+where
+    C: Compound<A>,
+    A: Annotation<C::Leaf>,
+    W: Walker<C, A>,
+    M: 'a,
+{
+    type Item = Result<&'a mut M, CanonError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match core::mem::replace(self, Self::Exhausted) {
+            Self::Initial(branch, walker) => {
+                *self = Self::Intermediate(branch, walker);
+            }
+            Self::Intermediate(mut branch, mut walker) => {
+                branch.inner.0.advance();
+                // access partialbranch
+                match branch.inner.0.walk(&mut walker) {
+                    Ok(None) => {
+                        *self = Self::Exhausted;
+                        return None;
+                    }
+                    Ok(Some(..)) => {
+                        *self = Self::Intermediate(branch, walker);
+                    }
+                    Err(e) => {
+                        return Some(Err(e));
+                    }
+                }
+            }
+            Self::Exhausted => {
+                return None;
+            }
+        }
+
+        match self {
+            Self::Intermediate(branch, _) => {
+                let leaf: &mut M = &mut *branch;
+                let leaf_extended: &'a mut M =
                     unsafe { core::mem::transmute(leaf) };
                 Some(Ok(leaf_extended))
             }

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -1,0 +1,138 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use alloc::vec::Vec;
+
+use arbitrary::Arbitrary;
+use canonical::{Canon, CanonError, EncodeToVec, Id, Source};
+use canonical_derive::Canon;
+
+use crate::link::Link;
+use crate::{Annotation, Compound};
+
+const TAG_EMPTY: u8 = 0;
+const TAG_LEAF: u8 = 1;
+const TAG_LINK: u8 = 2;
+
+/// A generic annotation
+#[derive(Clone, Canon, Debug, PartialEq, Arbitrary)]
+pub struct GenericAnnotation(Vec<u8>);
+
+/// A generic leaf
+#[derive(Clone, Canon, Debug, PartialEq, Arbitrary)]
+pub struct GenericLeaf(Vec<u8>);
+
+impl GenericLeaf {
+    pub(crate) fn new<C: Canon>(c: &C) -> Self {
+        GenericLeaf(c.encode_to_vec())
+    }
+
+    /// Cast the generic leaf to a concrete type
+    pub fn cast<T: Canon>(&self) -> Result<T, CanonError> {
+        T::decode(&mut Source::new(&self.0))
+    }
+}
+
+impl GenericAnnotation {
+    pub(crate) fn new<A: Canon>(a: &A) -> Self {
+        GenericAnnotation(a.encode_to_vec())
+    }
+
+    /// Cast the generic leaf to a concrete type
+    pub fn cast<A: Canon>(&self) -> Result<A, CanonError> {
+        A::decode(&mut Source::new(&self.0))
+    }
+}
+
+/// A generic child of a collection
+#[derive(Clone, Debug, PartialEq, Arbitrary)]
+pub enum GenericChild {
+    /// Child is empty
+    Empty,
+    /// Child is a leaf    
+    Leaf(GenericLeaf),
+    /// Child is a link        
+    Link(Id, GenericAnnotation),
+}
+
+impl Canon for GenericChild {
+    fn encode(&self, sink: &mut canonical::Sink) {
+        match self {
+            Self::Empty => TAG_EMPTY.encode(sink),
+            Self::Leaf(leaf) => {
+                TAG_LEAF.encode(sink);
+                leaf.encode(sink)
+            }
+            Self::Link(id, annotation) => {
+                TAG_LINK.encode(sink);
+                id.encode(sink);
+                annotation.encode(sink);
+            }
+        }
+    }
+
+    fn decode(source: &mut canonical::Source) -> Result<Self, CanonError> {
+        match u8::decode(source)? {
+            TAG_EMPTY => Ok(GenericChild::Empty),
+            TAG_LEAF => Ok(GenericChild::Leaf(GenericLeaf::decode(source)?)),
+            TAG_LINK => {
+                let id = Id::decode(source)?;
+                let anno = GenericAnnotation::decode(source)?;
+                Ok(GenericChild::Link(id, anno))
+            }
+            _ => Err(CanonError::InvalidEncoding),
+        }
+    }
+
+    fn encoded_len(&self) -> usize {
+        const TAG_LEN: usize = 1;
+        match self {
+            Self::Empty => TAG_LEN,
+            Self::Leaf(leaf) => TAG_LEN + leaf.encoded_len(),
+            Self::Link(id, anno) => {
+                TAG_LEN + id.encoded_len() + anno.encoded_len()
+            }
+        }
+    }
+}
+
+/// The generic tree structure, this is a generic version of any Compound tree,
+/// which has had it's leaves and annotations replaced with generic variants of
+/// prefixed lengths, so that the tree structure can still be followed even if
+/// you don't know the concrete associated and generic types of the Compound
+/// structure that was persisted
+#[derive(Default, Clone, Canon, Debug, PartialEq, Arbitrary)]
+pub struct GenericTree(Vec<GenericChild>);
+
+impl GenericTree {
+    pub(crate) fn new() -> Self {
+        GenericTree(vec![])
+    }
+
+    pub(crate) fn push_empty(&mut self) {
+        self.0.push(GenericChild::Empty)
+    }
+
+    pub(crate) fn push_leaf<L: Canon>(&mut self, leaf: &L) {
+        self.0.push(GenericChild::Leaf(GenericLeaf::new(leaf)))
+    }
+
+    pub(crate) fn push_link<C, A>(&mut self, link: &Link<C, A>)
+    where
+        C: Compound<A>,
+        C::Leaf: Canon,
+        A: Annotation<C::Leaf>,
+    {
+        let id = link.id();
+        let anno = GenericAnnotation::new(&*link.annotation());
+        self.0.push(GenericChild::Link(id, anno));
+    }
+
+    /// Provides an iterator over the generic children of the node
+    pub fn children(&self) -> &[GenericChild] {
+        &self.0
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! `Branch` and `BranchMut`, types for representing branches in tree-formed
 //! data as well as methods of search.
 
-#![no_std]
+#![cfg_attr(not(feature = "persistance"), no_std)]
 #![deny(missing_docs)]
 
 #[macro_use]
@@ -23,12 +23,26 @@ mod annotations;
 mod branch;
 mod branch_mut;
 mod compound;
+mod generic;
+mod link;
 mod walk;
 
+#[cfg(feature = "persistance")]
+mod persist;
+
 pub use annotations::{
-    Annotated, Annotation, Cardinality, Combine, GetMaxKey, Keyed, MaxKey, Nth,
+    Annotation, Cardinality, Combine, GetMaxKey, Keyed, MaxKey, Nth,
 };
 pub use branch::Branch;
 pub use branch_mut::BranchMut;
-pub use compound::{Child, ChildMut, Compound, IterChild, MutableLeaves};
+
+pub use compound::{AnnoIter, Child, ChildMut, Compound, MutableLeaves};
+pub use generic::{GenericAnnotation, GenericChild, GenericLeaf, GenericTree};
+pub use link::{Link, LinkAnnotation, LinkCompound, LinkCompoundMut};
 pub use walk::{First, Step, Walk, Walker};
+
+#[cfg(feature = "persistance")]
+pub use persist::{
+    Backend, BackendCtor, DiskBackend, PersistError, Persistance, PersistedId,
+    PutResult,
+};

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,0 +1,290 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use alloc::rc::Rc;
+use core::cell::{Ref, RefCell, RefMut};
+use core::mem;
+use core::ops::{Deref, DerefMut};
+
+use canonical::{Canon, CanonError, Id, Sink, Source};
+
+#[cfg(feature = "persistance")]
+use crate::persist::{PersistError, Persistance};
+
+use crate::{Annotation, Compound};
+
+#[derive(Debug, Clone)]
+enum LinkInner<C, A> {
+    Placeholder,
+    C(Rc<C>),
+    Ca(Rc<C>, A),
+    Ia(Id, A),
+    #[allow(unused)]
+    Ica(Id, Rc<C>, A),
+}
+
+#[derive(Clone)]
+/// TODO
+pub struct Link<C, A> {
+    inner: RefCell<LinkInner<C, A>>,
+}
+
+impl<C: core::fmt::Debug, A: core::fmt::Debug> core::fmt::Debug for Link<C, A> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{:?}", self.inner)
+    }
+}
+
+impl<C, A> Link<C, A>
+where
+    C: Compound<A>,
+    C::Leaf: Canon,
+    A: Canon,
+{
+    /// Create a new link
+    pub fn new(compound: C) -> Self
+    where
+        A: Annotation<C::Leaf>,
+    {
+        Link {
+            inner: RefCell::new(LinkInner::C(Rc::new(compound))),
+        }
+    }
+
+    /// Creates a new link from an id and annotation
+    pub fn new_persisted(id: Id, annotation: A) -> Self {
+        Link {
+            inner: RefCell::new(LinkInner::Ia(id, annotation)),
+        }
+    }
+
+    /// Returns a reference to to the annotation stored
+    pub fn annotation(&self) -> LinkAnnotation<C, A>
+    where
+        A: Annotation<C::Leaf>,
+    {
+        let borrow = self.inner.borrow();
+        let a = match *borrow {
+            LinkInner::Ca(_, _)
+            | LinkInner::Ica(_, _, _)
+            | LinkInner::Ia(_, _) => return LinkAnnotation(borrow),
+            LinkInner::C(ref c) => A::combine(c.annotations()),
+            LinkInner::Placeholder => unreachable!(),
+        };
+
+        drop(borrow);
+        let mut borrow = self.inner.borrow_mut();
+
+        if let LinkInner::C(c) =
+            mem::replace(&mut *borrow, LinkInner::Placeholder)
+        {
+            *borrow = LinkInner::Ca(c, a)
+        } else {
+            unreachable!()
+        }
+        drop(borrow);
+        let borrow = self.inner.borrow();
+        LinkAnnotation(borrow)
+    }
+
+    /// Gets a reference to the inner compound of the link'
+    ///
+    /// Can fail when trying to fetch data over i/o
+    pub fn into_compound(self) -> Result<C, CanonError>
+    where
+        C::Leaf: Canon,
+    {
+        // assure compound is loaded
+        let _ = self.compound()?;
+
+        let inner = self.inner.into_inner();
+        match inner {
+            LinkInner::C(rc)
+            | LinkInner::Ca(rc, _)
+            | LinkInner::Ica(_, rc, _) => match Rc::try_unwrap(rc) {
+                Ok(c) => Ok(c),
+                Err(rc) => Ok((&*rc).clone()),
+            },
+
+            _ => unreachable!(),
+        }
+    }
+
+    /// Computes the Id of the
+    pub fn id(&self) -> Id
+    where
+        C::Leaf: Canon,
+        A: Annotation<C::Leaf>,
+    {
+        let borrow = self.inner.borrow();
+        match &*borrow {
+            LinkInner::Placeholder => unreachable!(),
+            LinkInner::C(c) | LinkInner::Ca(c, _) => {
+                let gen = c.generic();
+                Id::new(&gen)
+            }
+            LinkInner::Ia(id, _) | LinkInner::Ica(id, _, _) => *id,
+        }
+    }
+
+    /// Gets a reference to the inner compound of the link'
+    ///
+    /// Can fail when trying to fetch data over i/o
+    pub fn compound(&self) -> Result<LinkCompound<C, A>, CanonError> {
+        let borrow = self.inner.borrow();
+
+        match *borrow {
+            LinkInner::Placeholder => unreachable!(),
+            LinkInner::C(_) | LinkInner::Ca(_, _) | LinkInner::Ica(_, _, _) => {
+                return Ok(LinkCompound(borrow))
+            }
+            LinkInner::Ia(_, _) => {
+                #[cfg(feature = "persistance")]
+                {
+                    // re-borrow mutable
+                    drop(borrow);
+                    let mut borrow = self.inner.borrow_mut();
+                    if let LinkInner::Ia(id, anno) =
+                        mem::replace(&mut *borrow, LinkInner::Placeholder)
+                    {
+                        match Persistance::get(&id) {
+                            Ok(generic) => {
+                                let compound = C::from_generic(&generic)?;
+                                *borrow =
+                                    LinkInner::Ica(id, Rc::new(compound), anno);
+
+                                // re-borrow immutable
+                                drop(borrow);
+                                let borrow = self.inner.borrow();
+
+                                Ok(LinkCompound(borrow))
+                            }
+                            Err(PersistError::Canon(e)) => Err(e),
+                            Err(PersistError::Io(_)) => {
+                                Err(CanonError::NotFound)
+                            }
+                        }
+                    } else {
+                        unreachable!()
+                    }
+                }
+                #[cfg(not(feature = "persistance"))]
+                Err(CanonError::NotFound)
+            }
+        }
+    }
+
+    /// Returns a Mutable reference to the underlying compound node
+    ///
+    /// Drops cached annotations and ids
+    ///
+    /// Can fail when trying to fetch data over i/o
+    pub fn compound_mut(&mut self) -> Result<LinkCompoundMut<C, A>, CanonError>
+    where
+        C: Canon,
+    {
+        // assure compound is loaded
+        let _ = self.compound()?;
+
+        let mut borrow: RefMut<LinkInner<C, A>> = self.inner.borrow_mut();
+
+        match mem::replace(&mut *borrow, LinkInner::Placeholder) {
+            LinkInner::C(c) | LinkInner::Ca(c, _) | LinkInner::Ica(_, c, _) => {
+                // clear all cached data
+                *borrow = LinkInner::C(c);
+            }
+            _ => unreachable!(),
+        }
+        Ok(LinkCompoundMut(borrow))
+    }
+}
+
+impl<C, A> Canon for Link<C, A>
+where
+    C: Compound<A> + Canon,
+    C::Leaf: Canon,
+    A: Annotation<C::Leaf>,
+{
+    fn encode(&self, sink: &mut Sink) {
+        self.id().encode(sink);
+        self.annotation().encode(sink);
+    }
+
+    fn decode(source: &mut Source) -> Result<Self, CanonError> {
+        let id = Id::decode(source)?;
+        let a = A::decode(source)?;
+        Ok(Link {
+            inner: RefCell::new(LinkInner::Ia(id, a)),
+        })
+    }
+
+    fn encoded_len(&self) -> usize {
+        self.id().encoded_len() + self.annotation().encoded_len()
+    }
+}
+
+/// A wrapped borrow of an inner link guaranteed to contain a computed
+/// annotation
+#[derive(Debug)]
+pub struct LinkAnnotation<'a, C, A>(Ref<'a, LinkInner<C, A>>);
+
+/// A wrapped borrow of an inner node guaranteed to contain a compound node
+#[derive(Debug)]
+pub struct LinkCompound<'a, C, A>(Ref<'a, LinkInner<C, A>>);
+
+/// A wrapped mutable borrow of an inner node guaranteed to contain a compound
+/// node
+#[derive(Debug)]
+pub struct LinkCompoundMut<'a, C, A>(RefMut<'a, LinkInner<C, A>>);
+
+impl<'a, C, A> Deref for LinkAnnotation<'a, C, A> {
+    type Target = A;
+
+    fn deref(&self) -> &Self::Target {
+        match *self.0 {
+            LinkInner::Ica(_, _, ref a)
+            | LinkInner::Ia(_, ref a)
+            | LinkInner::Ca(_, ref a) => a,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<'a, C, A> Deref for LinkCompound<'a, C, A> {
+    type Target = C;
+
+    fn deref(&self) -> &Self::Target {
+        match *self.0 {
+            LinkInner::C(ref c)
+            | LinkInner::Ca(ref c, _)
+            | LinkInner::Ica(_, ref c, _) => c,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<'a, C, A> Deref for LinkCompoundMut<'a, C, A> {
+    type Target = C;
+
+    fn deref(&self) -> &Self::Target {
+        match *self.0 {
+            LinkInner::C(ref c) => c,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<'a, C, A> DerefMut for LinkCompoundMut<'a, C, A>
+where
+    C: Clone,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match *self.0 {
+            LinkInner::C(ref mut c) => Rc::make_mut(c),
+            _ => unreachable!(),
+        }
+    }
+}

--- a/src/persist/disk.rs
+++ b/src/persist/disk.rs
@@ -1,0 +1,112 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::path::PathBuf;
+
+use appendix::Index;
+use canonical::{Canon, CanonError, Id, Source};
+
+use crate::generic::GenericTree;
+use crate::persist::{Backend, PersistError, PutResult};
+
+/// A disk-store for persisting microkelvin compound structures
+pub struct DiskBackend {
+    index: Index<Id, u64>,
+    data_path: PathBuf,
+    data_ofs: u64,
+}
+
+impl std::fmt::Debug for DiskBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "DiskBackend {{ path: {:?}, data_ofs: {:?} }}",
+            self.data_path, self.data_ofs
+        )
+    }
+}
+
+impl DiskBackend {
+    /// Create a new disk backend
+    pub fn new<P>(path: P) -> io::Result<Self>
+    where
+        P: Into<PathBuf>,
+    {
+        let path = path.into();
+
+        let index_path = path.join("index");
+        let data_path = path.join("data");
+
+        fs::create_dir(&index_path)?;
+
+        let index = Index::new(&index_path)?;
+
+        let mut data = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .open(&data_path)?;
+
+        data.seek(SeekFrom::End(0))?;
+
+        let data_ofs = data.metadata()?.len();
+
+        Ok(DiskBackend {
+            data_path,
+            index,
+            data_ofs,
+        })
+    }
+}
+
+impl Backend for DiskBackend {
+    fn get(&self, id: &Id) -> Result<GenericTree, PersistError> {
+        if let Some(ofs) = self.index.get(id)? {
+            let mut data = File::open(&self.data_path)?;
+
+            data.seek(SeekFrom::Start(*ofs))?;
+
+            let len = id.size();
+            let mut buf = vec![0u8; len];
+            let read_res = data.read_exact(&mut buf[..]);
+
+            read_res?;
+
+            let mut source = Source::new(&buf);
+            Ok(GenericTree::decode(&mut source)?)
+        } else {
+            Err(CanonError::NotFound.into())
+        }
+    }
+
+    fn put(
+        &mut self,
+        id: &Id,
+        bytes: &[u8],
+    ) -> Result<PutResult, PersistError> {
+        if self.index.get(id)?.is_some() {
+            return Ok(PutResult::AlreadyPresent);
+        } else {
+            let data_len = id.size();
+            assert_eq!(data_len, bytes.len());
+
+            let mut data = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .append(true)
+                .open(&self.data_path)?;
+
+            data.write_all(bytes)?;
+
+            self.index.insert(*id, self.data_ofs)?;
+            self.index.flush()?;
+            self.data_ofs += data_len as u64;
+
+            Ok(PutResult::Written)
+        }
+    }
+}

--- a/src/persist/mod.rs
+++ b/src/persist/mod.rs
@@ -1,0 +1,196 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use std::hash::Hasher;
+use std::io;
+use std::sync::Arc;
+use std::{
+    collections::hash_map::{DefaultHasher, Entry, HashMap},
+    hash::Hash,
+};
+
+mod disk;
+
+use crate::Child;
+use canonical::{Canon, CanonError, Id};
+use lazy_static::lazy_static;
+use parking_lot::{RwLock, RwLockWriteGuard};
+
+pub use disk::DiskBackend;
+
+use crate::{Annotation, Compound, GenericTree};
+pub(crate) struct WrappedBackend(Arc<RwLock<dyn Backend>>);
+
+impl WrappedBackend {
+    fn new<B: 'static + Backend>(backend: B) -> Self {
+        WrappedBackend(Arc::new(RwLock::new(backend)))
+    }
+
+    pub fn get(&self, id: &Id) -> Result<GenericTree, PersistError> {
+        self.0.read().get(id)
+    }
+
+    fn persist<C: Compound<A>, A>(
+        &self,
+        tree: &C,
+    ) -> Result<PersistedId, PersistError>
+    where
+        C::Leaf: Canon,
+        A: Annotation<C::Leaf>,
+    {
+        Self::persist_inner(&mut self.0.write(), tree)
+    }
+
+    pub fn persist_inner<C: Compound<A>, A>(
+        backend: &mut RwLockWriteGuard<dyn Backend>,
+        tree: &C,
+    ) -> Result<PersistedId, PersistError>
+    where
+        C::Leaf: Canon,
+        A: Annotation<C::Leaf>,
+    {
+        let generic = tree.generic();
+        let id = Id::new(&generic);
+
+        if let Some(bytes) = id.take_bytes()? {
+            match backend.put(&id, &bytes[..])? {
+                PutResult::Written => {
+                    // Recursively store the children if not already in backend
+                    for i in 0.. {
+                        match tree.child(i) {
+                            Child::Node(node) => {
+                                Self::persist_inner(
+                                    backend,
+                                    &*node.compound()?,
+                                )?;
+                            }
+                            Child::EndOfNode => break,
+                            _ => (),
+                        }
+                    }
+                }
+                PutResult::AlreadyPresent => (),
+            }
+        }
+
+        Ok(PersistedId(id))
+    }
+}
+
+lazy_static! {
+    static ref BACKENDS: Arc<RwLock<HashMap<u64, WrappedBackend>>> =
+        Arc::new(RwLock::new(HashMap::new()));
+}
+
+/// A backend constructor
+pub struct BackendCtor<B> {
+    ctor: fn() -> B,
+    id: u64,
+}
+
+impl<B> BackendCtor<B> {
+    /// Create a new constructor from a function/closure
+    pub fn new(ctor: fn() -> B) -> Self {
+        let mut hasher = DefaultHasher::new();
+        Hash::hash(&ctor, &mut hasher);
+        let id = hasher.finish();
+        BackendCtor { ctor, id }
+    }
+}
+
+/// Id of a persisted GenericTree
+pub struct PersistedId(Id);
+
+impl PersistedId {
+    /// Restore a GenericTree from a persistance backend.
+    pub fn restore(&self) -> Result<GenericTree, PersistError> {
+        Persistance::get(&self.0)
+    }
+}
+
+/// The singleton interface to the persistance layer
+pub struct Persistance;
+
+impl Persistance {
+    /// Persist the given Compound to a backend
+    pub fn persist<C, A, B>(
+        ctor: &BackendCtor<B>,
+        c: &C,
+    ) -> Result<PersistedId, PersistError>
+    where
+        C: Compound<A>,
+        C::Leaf: Canon,
+        A: Annotation<C::Leaf>,
+        B: 'static + Backend,
+    {
+        let mut backends = BACKENDS.write();
+        let entry = backends.entry(ctor.id);
+
+        match entry {
+            Entry::Occupied(mut occupied) => occupied.get_mut().persist(c),
+            Entry::Vacant(vacant) => {
+                let backend = (ctor.ctor)();
+                vacant.insert(WrappedBackend::new(backend)).persist(c)
+            }
+        }
+    }
+
+    /// Get a generic tree from the backend.
+    pub fn get(id: &Id) -> Result<GenericTree, PersistError> {
+        // First try reifying from local store/inlined data
+        if let Ok(tree) = id.reify() {
+            return Ok(tree);
+        }
+
+        let backends = BACKENDS.read();
+
+        for (_, backend) in backends.iter() {
+            if let Ok(tree) = backend.get(id) {
+                return Ok(tree);
+            }
+        }
+        Err(CanonError::NotFound.into())
+    }
+}
+
+/// The trait defining a disk or network backend for microkelvin structures.
+pub trait Backend: Send + Sync {
+    /// Get get a generic tree stored in the backend from an `Id`
+    fn get(&self, id: &Id) -> Result<GenericTree, PersistError>;
+
+    /// Write encoded bytes with a corresponding `Id` into the backend
+    fn put(&mut self, id: &Id, bytes: &[u8])
+        -> Result<PutResult, PersistError>;
+}
+
+/// An error that can appear when persisting structures to disk
+#[derive(Debug)]
+pub enum PersistError {
+    /// An io-error occured while persisting
+    Io(io::Error),
+    /// A CanonError occured while persisting
+    Canon(CanonError),
+}
+
+impl From<io::Error> for PersistError {
+    fn from(e: io::Error) -> Self {
+        PersistError::Io(e)
+    }
+}
+
+impl From<CanonError> for PersistError {
+    fn from(e: CanonError) -> Self {
+        PersistError::Canon(e)
+    }
+}
+
+/// Type to indicate if the backend already contained the value to write
+pub enum PutResult {
+    /// The bytes were written to the backend
+    Written,
+    /// The bytes were already present in the backend
+    AlreadyPresent,
+}

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -6,9 +6,8 @@
 
 use core::marker::PhantomData;
 
-use canonical::CanonError;
+use canonical::{Canon, CanonError};
 
-use crate::annotations::Combine;
 use crate::branch::Branch;
 use crate::branch_mut::BranchMut;
 use crate::compound::{Child, Compound, MutableLeaves};
@@ -37,7 +36,6 @@ pub struct Walk<'a, C, A> {
 impl<'a, C, A> Walk<'a, C, A>
 where
     C: Compound<A>,
-    A: Combine<C, A>,
 {
     pub(crate) fn new(compound: &'a C, ofs: usize) -> Self {
         Walk {
@@ -57,9 +55,8 @@ where
 pub trait Walker<C, A>
 where
     C: Compound<A>,
-    A: Combine<C, A>,
 {
-    /// Walks the node selecting a leaf or a node, aborting or proceeding
+    /// Walk the tree node, returning the appropriate `Step`
     fn walk(&mut self, walk: Walk<C, A>) -> Step;
 }
 
@@ -69,7 +66,6 @@ pub struct AllLeaves;
 impl<C, A> Walker<C, A> for AllLeaves
 where
     C: Compound<A>,
-    A: Combine<C, A>,
 {
     fn walk(&mut self, walk: Walk<C, A>) -> Step {
         for i in 0.. {
@@ -89,7 +85,6 @@ where
 pub trait First<'a, A>
 where
     Self: Compound<A>,
-    A: Combine<Self, A>,
 {
     /// Construct a `Branch` pointing to the first element, if not empty
     fn first(&'a self) -> Result<Option<Branch<'a, Self, A>>, CanonError>;
@@ -99,13 +94,13 @@ where
         &'a mut self,
     ) -> Result<Option<BranchMut<'a, Self, A>>, CanonError>
     where
-        Self: MutableLeaves;
+        Self: MutableLeaves + Clone;
 }
 
 impl<'a, C, A> First<'a, A> for C
 where
-    C: Compound<A> + Clone,
-    A: Combine<C, A>,
+    C: Compound<A>,
+    A: Canon,
 {
     fn first(&'a self) -> Result<Option<Branch<'a, Self, A>>, CanonError> {
         Branch::<_, A>::walk(self, AllLeaves)
@@ -115,8 +110,7 @@ where
         &'a mut self,
     ) -> Result<Option<BranchMut<'a, Self, A>>, CanonError>
     where
-        A: Combine<Self, A>,
-        C: MutableLeaves,
+        C: MutableLeaves + Clone,
     {
         BranchMut::<_, A>::walk(self, AllLeaves)
     }

--- a/tests/generic.rs
+++ b/tests/generic.rs
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use microkelvin::{GenericChild, GenericTree};
+
+use canonical_fuzz::fuzz_canon;
+
+#[test]
+fn fuzz_generic_tree() {
+    fuzz_canon::<GenericTree>()
+}
+
+#[test]
+fn fuzz_generic_child() {
+    fuzz_canon::<GenericChild>()
+}

--- a/tests/linked_list.rs
+++ b/tests/linked_list.rs
@@ -4,20 +4,27 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use canonical::Canon;
+use canonical::{Canon, CanonError};
 use canonical_derive::Canon;
+
 use microkelvin::{
-    Annotated, Annotation, Child, ChildMut, Combine, Compound, First,
-    MutableLeaves,
+    Annotation, Child, ChildMut, Compound, First, GenericChild, GenericTree,
+    Link, MutableLeaves,
 };
 
-#[derive(Clone, Canon, Debug)]
-pub enum LinkedList<T, A> {
+#[derive(Clone, Debug, Canon)]
+pub enum LinkedList<T, A>
+where
+    A: Annotation<T>,
+{
     Empty,
-    Node { val: T, next: Annotated<Self, A> },
+    Node { val: T, next: Link<Self, A> },
 }
 
-impl<T, A> Default for LinkedList<T, A> {
+impl<T, A> Default for LinkedList<T, A>
+where
+    A: Annotation<T>,
+{
     fn default() -> Self {
         LinkedList::Empty
     }
@@ -25,8 +32,8 @@ impl<T, A> Default for LinkedList<T, A> {
 
 impl<T, A> Compound<A> for LinkedList<T, A>
 where
+    A: Annotation<T>,
     T: Canon,
-    A: Canon,
 {
     type Leaf = T;
 
@@ -53,50 +60,90 @@ where
             (LinkedList::Empty, _) => ChildMut::EndOfNode,
         }
     }
+
+    fn from_generic(tree: &GenericTree) -> Result<Self, CanonError>
+    where
+        Self::Leaf: Canon,
+        A: Canon,
+    {
+        let mut children = tree.children().iter();
+
+        let val: Self::Leaf = match children.next() {
+            Some(GenericChild::Leaf(leaf)) => leaf.cast()?,
+            None => return Ok(LinkedList::Empty),
+            _ => return Err(CanonError::InvalidEncoding),
+        };
+
+        match children.next() {
+            Some(GenericChild::Empty) => Ok(LinkedList::Node {
+                val,
+                next: Link::new(LinkedList::Empty),
+            }),
+            Some(GenericChild::Link(id, annotation)) => Ok(LinkedList::Node {
+                val,
+                next: Link::new_persisted(*id, annotation.cast()?),
+            }),
+            _ => Err(CanonError::InvalidEncoding),
+        }
+    }
 }
 
-impl<T, A> MutableLeaves for LinkedList<T, A> {}
+impl<T, A> MutableLeaves for LinkedList<T, A> where A: Annotation<T> {}
 
 impl<T, A> LinkedList<T, A>
 where
-    Self: Compound<A>,
-    A: Combine<Self, A>,
+    A: Annotation<T>,
+    T: Canon,
 {
     pub fn new() -> Self {
         Default::default()
     }
 
-    pub fn insert(&mut self, t: T) {
+    pub fn push(&mut self, t: T) {
         match core::mem::take(self) {
             LinkedList::Empty => {
                 *self = LinkedList::Node {
                     val: t,
-                    next: Annotated::new(LinkedList::Empty),
+                    next: Link::new(LinkedList::<T, A>::Empty),
                 }
             }
             old @ LinkedList::Node { .. } => {
                 *self = LinkedList::Node {
                     val: t,
-                    next: Annotated::new(old),
+                    next: Link::new(old),
                 };
+            }
+        }
+    }
+
+    pub fn pop(&mut self) -> Result<Option<T>, CanonError>
+    where
+        T: Canon,
+        A: Canon,
+    {
+        match core::mem::take(self) {
+            LinkedList::Empty => Ok(None),
+            LinkedList::Node { val: t, next } => {
+                *self = next.into_compound()?;
+                Ok(Some(t))
             }
         }
     }
 }
 
 #[test]
-fn insert() {
+fn push() {
     let n: u64 = 1024;
 
     let mut list = LinkedList::<_, ()>::new();
 
     for i in 0..n {
-        list.insert(i)
+        list.push(i)
     }
 }
 
 #[test]
-fn insert_cardinality() {
+fn push_cardinality() {
     let n: u64 = 1024;
 
     use microkelvin::Cardinality;
@@ -104,12 +151,12 @@ fn insert_cardinality() {
     let mut list = LinkedList::<_, Cardinality>::new();
 
     for i in 0..n {
-        list.insert(i)
+        list.push(i)
     }
 }
 
 #[test]
-fn insert_nth() {
+fn push_nth() {
     let n: u64 = 1024;
 
     use microkelvin::{Cardinality, Nth};
@@ -117,7 +164,7 @@ fn insert_nth() {
     let mut list = LinkedList::<_, Cardinality>::new();
 
     for i in 0..n {
-        list.insert(i)
+        list.push(i)
     }
 
     for i in 0..n {
@@ -126,7 +173,22 @@ fn insert_nth() {
 }
 
 #[test]
-fn insert_mut() {
+fn push_pop() {
+    let n: u64 = 1024;
+
+    let mut list = LinkedList::<_, ()>::new();
+
+    for i in 0..n {
+        list.push(i)
+    }
+
+    for i in 0..n {
+        assert_eq!(list.pop().unwrap(), Some(n - i - 1))
+    }
+}
+
+#[test]
+fn push_mut() {
     let n: u64 = 1024;
 
     use microkelvin::{Cardinality, Nth};
@@ -134,7 +196,7 @@ fn insert_mut() {
     let mut list = LinkedList::<_, Cardinality>::new();
 
     for i in 0..n {
-        list.insert(i)
+        list.push(i)
     }
 
     for i in 0..n {
@@ -148,14 +210,14 @@ fn insert_mut() {
 
 #[test]
 fn iterate_immutable() {
-    let n: u64 = 4;
+    let n: u64 = 16;
 
     use microkelvin::{Cardinality, Nth};
 
     let mut list = LinkedList::<_, Cardinality>::new();
 
     for i in 0..n {
-        list.insert(i)
+        list.push(i)
     }
 
     // branch from first element
@@ -171,10 +233,10 @@ fn iterate_immutable() {
         assert_eq!(*leaf, count);
     }
 
-    // branch from 8th element
-    let branch = list.nth(2).unwrap().unwrap();
+    // branch from 7th element
+    let branch = list.nth(6).unwrap().unwrap();
 
-    let mut count = n - 2;
+    let mut count = n - 6;
 
     for res_leaf in branch {
         let leaf = res_leaf.unwrap();
@@ -194,7 +256,7 @@ fn iterate_mutable() {
     let mut list = LinkedList::<_, Cardinality>::new();
 
     for i in 0..n {
-        list.insert(i)
+        list.push(i)
     }
 
     // branch from first element
@@ -229,4 +291,71 @@ fn iterate_mutable() {
 
         count -= 1;
     }
+}
+
+#[test]
+fn iterate_map() {
+    let n: u64 = 32;
+
+    let mut list = LinkedList::<_, ()>::new();
+
+    for i in 0..n {
+        list.push(i)
+    }
+
+    // branch from first element
+    let branch_mut = list.first().unwrap().unwrap();
+    let mapped = branch_mut.map_leaf(|x| x);
+
+    let mut count = n - 1;
+
+    for leaf in mapped {
+        let leaf = leaf.unwrap();
+
+        assert_eq!(*leaf, count);
+
+        count = count.saturating_sub(1);
+    }
+}
+
+#[test]
+fn iterate_map_mutable() {
+    let n: u64 = 32;
+
+    let mut list = LinkedList::<_, ()>::new();
+
+    for i in 0..n {
+        list.push(i)
+    }
+
+    // branch from first element
+    let branch_mut = list.first_mut().unwrap().unwrap();
+    let mapped = branch_mut.map_leaf(|x| x);
+
+    let mut count = n - 1;
+
+    for leaf in mapped {
+        let leaf = leaf.unwrap();
+
+        assert_eq!(*leaf, count);
+
+        count = count.saturating_sub(1);
+    }
+}
+
+#[test]
+fn deref_mapped_mutable_branch() {
+    let n: u64 = 32;
+
+    let mut list = LinkedList::<_, ()>::new();
+
+    for i in 0..n {
+        list.push(i)
+    }
+
+    // branch from first element
+    let branch_mut = list.first_mut().unwrap().unwrap();
+    let mapped = branch_mut.map_leaf(|x| x);
+
+    assert_eq!(core::ops::Deref::deref(&mapped), &31);
 }

--- a/tests/max.rs
+++ b/tests/max.rs
@@ -39,7 +39,7 @@ fn maximum() {
     let mut list = LinkedList::<_, MaxKey<u64>>::new();
 
     for key in keys {
-        list.insert(TestLeaf { key, other: () });
+        list.push(TestLeaf { key, other: () });
     }
 
     let max = list.max_key().unwrap().unwrap();

--- a/tests/persistance.rs
+++ b/tests/persistance.rs
@@ -1,0 +1,157 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+mod linked_list;
+
+#[cfg(feature = "persistance")]
+mod persist_tests {
+    use super::*;
+
+    use linked_list::LinkedList;
+
+    use canonical_derive::Canon;
+    use microkelvin::{BackendCtor, Compound, DiskBackend, Keyed, Persistance};
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread;
+    use std::time;
+
+    #[derive(PartialEq, Clone, Canon, Debug)]
+    struct TestLeaf {
+        key: u64,
+        other: (),
+    }
+
+    impl Keyed<u64> for TestLeaf {
+        fn key(&self) -> &u64 {
+            &self.key
+        }
+    }
+
+    static INIT_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    fn testbackend() -> BackendCtor<DiskBackend> {
+        BackendCtor::new(|| {
+            INIT_COUNTER.fetch_add(1, Ordering::SeqCst);
+
+            let dir = tempfile::tempdir().unwrap();
+            let b = DiskBackend::new(dir.path()).unwrap();
+            core::mem::forget(dir);
+            b
+        })
+    }
+
+    #[test]
+    fn persist_a() {
+        let n: u64 = 16;
+
+        let mut list = LinkedList::<_, ()>::new();
+
+        for i in 0..n {
+            list.push(i);
+        }
+
+        let persisted = Persistance::persist(&testbackend(), &list).unwrap();
+
+        let restored_generic = persisted.restore().unwrap();
+
+        let mut restored: LinkedList<u64, ()> =
+            LinkedList::from_generic(&restored_generic).unwrap();
+
+        // first empty the original
+
+        for i in 0..n {
+            assert_eq!(list.pop().unwrap(), Some(n - i - 1));
+        }
+
+        // then the restored copy
+
+        for i in 0..n {
+            assert_eq!(restored.pop().unwrap(), Some(n - i - 1));
+        }
+    }
+
+    // Identical to persist_a, to test concurrency
+
+    #[test]
+    fn persist_b() {
+        let n: u64 = 16;
+
+        let mut list = LinkedList::<_, ()>::new();
+
+        for i in 0..n {
+            list.push(i);
+        }
+
+        let persisted = Persistance::persist(&testbackend(), &list).unwrap();
+
+        let restored_generic = persisted.restore().unwrap();
+
+        let mut restored: LinkedList<u64, ()> =
+            LinkedList::from_generic(&restored_generic).unwrap();
+
+        // first empty the original
+
+        for i in 0..n {
+            assert_eq!(list.pop().unwrap(), Some(n - i - 1));
+        }
+
+        // then the restored copy
+
+        for i in 0..n {
+            assert_eq!(restored.pop().unwrap(), Some(n - i - 1));
+        }
+    }
+
+    // this test should work across threads!
+
+    #[test]
+    fn persist_across_threads() {
+        let n: u64 = 16;
+
+        let mut list = LinkedList::<_, ()>::new();
+
+        for i in 0..n {
+            list.push(i);
+        }
+
+        let persisted = Persistance::persist(&testbackend(), &list).unwrap();
+
+        // it should now be available from other threads
+
+        std::thread::spawn(move || {
+            let restored_generic = persisted.restore().unwrap();
+
+            let mut restored: LinkedList<u64, ()> =
+                LinkedList::from_generic(&restored_generic).unwrap();
+
+            for i in 0..n {
+                assert_eq!(restored.pop().unwrap(), Some(n - i - 1));
+            }
+        })
+        .join()
+        .unwrap();
+
+        // then empty the original
+
+        for i in 0..n {
+            assert_eq!(list.pop().unwrap(), Some(n - i - 1));
+        }
+    }
+
+    #[test]
+    fn persist_create_once() {
+        while INIT_COUNTER.load(Ordering::SeqCst) == 0 {}
+
+        for _ in 0..128 {
+            assert_eq!(INIT_COUNTER.load(Ordering::SeqCst), 1);
+
+            thread::sleep(time::Duration::from_millis(1));
+
+            assert_eq!(INIT_COUNTER.load(Ordering::SeqCst), 1);
+        }
+    }
+}


### PR DESCRIPTION
### Added
- Add feature `persistance` (fixes #44)
- Add `DiskBackend` to persist datastructures to disk
- Add `Persistance` to interact with the persistance layer
- Add `IntoIterator` to `MappedBranch` and `BranchMutMappedMut`
- Add support for non-mutably dereferencing mutable mapped branches (fixes #53)

### Changed
- Change the name of `BranchMutMappedMut` to `MappedBranchMut`

### Removed
- Remove `path` from branch traversal, case now covered by `walk`
