### PR TITLE
add Clone derivation to PersistedId

### DIFF
--- a/src/persist/mod.rs
+++ b/src/persist/mod.rs
@@ -103,6 +103,7 @@ impl<B> BackendCtor<B> {
 }
 
 /// Id of a persisted GenericTree
+#[derive(Clone)]
 pub struct PersistedId(Id);
 
 impl PersistedId {


### PR DESCRIPTION
added Clone derivation for PersistedId to satisfy WasmerEnv constraint - it is needed for the wasmer migration of rusk-vm, the change is beneficial in general, as Id contained by PersistedId already implements Clone, so PersistedId, i.e. its container, also could/should implement Clone (Id is the only member)