### PR TITLE
Update version number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microkelvin"
-version = "0.10.0"
+version = "0.11.0-rc.0"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 keywords = ["datastructures"]


### PR DESCRIPTION
Updates the version number to `0.11.0-rc.0` to prepare for publishing the current state as a release candidate.