### PR TITLE
Add Canon, Clone, Copy and Debug to `PersistedId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2021-01-14
+
+### Added
+
+- Add Canon, Clone, Copy and Debug to `PersistedId`
+
 ## [0.10.0] - 2021-07-26
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microkelvin"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 keywords = ["datastructures"]

--- a/src/persist/mod.rs
+++ b/src/persist/mod.rs
@@ -17,6 +17,8 @@ mod disk;
 
 use crate::Child;
 use canonical::{Canon, CanonError, Id};
+use canonical_derive::Canon;
+
 use lazy_static::lazy_static;
 use parking_lot::{RwLock, RwLockWriteGuard};
 
@@ -103,6 +105,7 @@ impl<B> BackendCtor<B> {
 }
 
 /// Id of a persisted GenericTree
+#[derive(Canon, Clone, Copy, Debug)]
 pub struct PersistedId(Id);
 
 impl PersistedId {


### PR DESCRIPTION
This change is necessary in order to use rusk-vm inside Rusk, and to have the persisted id stored in the file system.

As you know testnet will initially use the stack based on canonical instead of archive.