### PR TITLE
 Fix `DiskBackend` using `fs::create_dir_all` instead of `fs:create_dir`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.10.1] - 2021-01-14
+## [0.10.3] - 2022-01-19
+
+### Fixed
+
+- Fix `DiskBackend` using `fs::create_dir_all` instead of `fs:create_dir`
+
+## [0.10.2] - 2022-01-17
+
+### Added
+
+- Add `with_backend` to `Persistance`
+
+## [0.10.1] - 2022-01-14
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microkelvin"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 keywords = ["datastructures"]

--- a/src/persist/disk.rs
+++ b/src/persist/disk.rs
@@ -47,7 +47,7 @@ impl DiskBackend {
         let index_path = path.join("index");
         let data_path = path.join("data");
 
-        fs::create_dir(&index_path)?;
+        fs::create_dir_all(&index_path)?;
 
         let index = Index::new(&index_path)?;
 


### PR DESCRIPTION
 - Update CHANGELOG.md
 - Bump to `0.10.3`