### PR TITLE
Fix `PersistError` type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,21 @@ canonical = "0.7"
 canonical_derive = "0.7"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 spin = { version = "0.9.2" }
+thiserror = { version = "1.0", optional = true }
+anyhow = { version = "1.0", optional = true }
 
 [dev-dependencies]
 rand = "0.8.3"
 canonical_fuzz = "0.7"
 
 [features]
-persistence = ["appendix",  "lazy_static", "tempfile", "arbitrary", "parking_lot", "blake2b_simd"]
+persistence = [
+  "appendix",
+  "lazy_static",
+  "tempfile",
+  "arbitrary",
+  "parking_lot",
+  "blake2b_simd",
+  "thiserror",
+  "anyhow"
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microkelvin"
-version = "0.15.0-rc.0"
+version = "0.15.0-rc.1"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 keywords = ["datastructures"]


### PR DESCRIPTION
- Add `thiserror` v1.0 when `persistence` feature is enabled
- Add `anyhow` v1.0 when `persistence` feature is enabled
- Change `PersistError` to use `thiserror::Error` trait and syntax
- Change `PersistError::Other` variant to wrap `anyhow::Error` instead of
  `Box<dyn std::error::Error + Send>`.

This changed was needed to satisfy wasmer imported functions types contraints.