### PR TITLE
Storage persistence in Microkelvin following RKYV migration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ readme = "README.md"
 rend = { version = "0.3.6", default_features = false }
 parking_lot = { version = "0.11.2", optional = true }
 rkyv = { version = "0.7.29", default_features = false, features = ["size_32", "archive_le", "validation"] }
-memmap = { version = "0.7.0", optional = true }
+#memmap = { version = "0.7.0", optional = true }
+memmap2 = { version = "0.5.3", optional = true }
 bytecheck = { version = "0.6.7", default_features = false }
 
 [dev-dependencies]
@@ -21,5 +22,5 @@ tempfile = "3.3.0"
 
 [features]
 default = ["host"]
-host = ["parking_lot", "memmap"]
+host = ["parking_lot", "memmap2"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microkelvin"
-version = "0.13.0-rc.1"
+version = "0.16.0-rkyv.1"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 keywords = ["datastructures"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 rend = { version = "0.3.6", default_features = false }
 parking_lot = { version = "0.11.2", optional = true }
 rkyv = { version = "0.7.29", default_features = false, features = ["size_32", "archive_le", "validation"] }
-#memmap = { version = "0.7.0", optional = true }
 memmap2 = { version = "0.5.3", optional = true }
 bytecheck = { version = "0.6.7", default_features = false }
 

--- a/src/storage/host_store.rs
+++ b/src/storage/host_store.rs
@@ -10,11 +10,11 @@ use memmap2::Mmap;
 use parking_lot::RwLock;
 use rkyv::Fallible;
 
+use rkyv::ser::Serializer;
 use std::fs::{File, OpenOptions};
-use std::io::{self, SeekFrom, Write, Seek};
+use std::io::{self, Seek, SeekFrom, Write};
 use std::path::Path;
 use std::sync::Arc;
-use rkyv::ser::Serializer;
 
 use crate::Store;
 
@@ -49,12 +49,12 @@ impl Page {
         }
     }
 
-    fn create(bytes: &[u8], written: usize) -> Self {
+    fn create(bytes: &[u8]) -> Self {
         let mut b = Box::new([0u8; PAGE_SIZE]);
-        b[..written].copy_from_slice(&bytes[..written]);
+        b[..bytes.len()].copy_from_slice(bytes);
         Page {
             bytes: b,
-            written,
+            written: bytes.len(),
         }
     }
 
@@ -118,14 +118,6 @@ impl PageStorage {
         size_sum
     }
 
-    fn uncommitted_pages_data_len(pages: &Vec<UncommittedPage>) -> usize {
-        let mut size_sum = 0;
-        for p in pages {
-            size_sum += p.written;
-        }
-        size_sum
-    }
-
     fn offset(&self) -> usize {
         self.mmap_len() + self.pages_data_len()
     }
@@ -150,13 +142,17 @@ impl PageStorage {
             for (i, p) in pages.iter().enumerate() {
                 sum += p.written;
                 if pages_ofs <= sum {
-                    return i
+                    return i;
                 }
             }
             unreachable!()
         }
         // generalized mod
-        fn page_ofs_for_ofs(pages_ofs: usize, pages: &Vec<Page>, cur_page: usize) -> usize {
+        fn page_ofs_for_ofs(
+            pages_ofs: usize,
+            pages: &Vec<Page>,
+            cur_page: usize,
+        ) -> usize {
             assert!(cur_page < pages.len());
             if cur_page == 0 {
                 pages_ofs
@@ -168,20 +164,19 @@ impl PageStorage {
                 pages_ofs - sum
             }
         }
-        // println!("get ofs={} len={} number of pages={}", ofs.offset(), ofs.len(), &self.pages.len());
         let OffsetLen(ofs, len) = *ofs;
         let (ofs, len) = (u64::from(ofs) as usize, u32::from(len) as usize);
 
         let slice = match &self.mmap {
-            Some(mmap) if (ofs + len) <= mmap.len() => {
-     
-                &mmap[ofs..][..len]
-            },
+            Some(mmap) if (ofs + len) <= mmap.len() => &mmap[ofs..][..len],
             _ => {
                 let pages_ofs = ofs - self.mmap_len();
                 let mut cur_page = page_for_ofs(pages_ofs, &self.pages);
-                let mut cur_page_ofs = page_ofs_for_ofs(pages_ofs, &self.pages, cur_page);
-                if page_for_ofs(pages_ofs, &self.pages) < page_for_ofs(pages_ofs + len, &self.pages) {
+                let mut cur_page_ofs =
+                    page_ofs_for_ofs(pages_ofs, &self.pages, cur_page);
+                if page_for_ofs(pages_ofs, &self.pages)
+                    < page_for_ofs(pages_ofs + len, &self.pages)
+                {
                     cur_page_ofs = 0;
                     cur_page += 1;
                 }
@@ -193,50 +188,39 @@ impl PageStorage {
     }
 
     fn commit(&mut self, buffer: &mut TokenBuffer) -> OffsetLen {
-        // println!("commit num uncommitted pages={} buffer pos={}", buffer.uncomitted_pages.len(), buffer.pos());
         let offset = self.offset();
         let written = buffer.pos();
-        if let Some(top_uncomitted_page) = buffer.uncomitted_pages.last_mut(){
-            top_uncomitted_page.written += written;
-        }
+        buffer.uncommitted_page().add_written(written);
         buffer.advance();
-        let mut uncommitted_len = 0;
-        for p in &buffer.uncomitted_pages {
-            uncommitted_len += p.written;
-            // println!("commit written={}", p.written);
-        }
-        if uncommitted_len <= self.unwritten_tail().len() && buffer.uncomitted_pages.len() == 1 {
-            self.unwritten_tail()[..uncommitted_len].copy_from_slice(unsafe { buffer.last_uncommitted_slice(uncommitted_len) });
-            if let Some(top_page) = self.pages.last_mut(){
-                top_page.written += written;
+        let uncommitted_len = buffer.uncommitted_len();
+        if uncommitted_len <= self.unwritten_tail().len() {
+            self.unwritten_tail()[..uncommitted_len].copy_from_slice(unsafe {
+                buffer.last_uncommitted_slice(uncommitted_len)
+            });
+            if let Some(top_page) = self.pages.last_mut() {
+                top_page.commit(written);
             }
         } else {
-            let uncommitted_size = PageStorage::uncommitted_pages_data_len(&buffer.uncomitted_pages);
-            if uncommitted_size < PAGE_SIZE {
-                for p in &buffer.uncomitted_pages {
-                    self.pages.push(Page::create(p.bytes.as_slice(), p.written));
-                }
+            if uncommitted_len <= PAGE_SIZE {
+                self.pages.push(Page::create(
+                    buffer.uncommitted_page().written_slice(),
+                ));
             } else {
-                self.persist(&buffer.uncomitted_pages);
-                println!("xcommit persists as uncommitted size is {}", uncommitted_size);
+                self.persist(&buffer.uncommitted_pages())
+                    .expect("Host store persistence");
             }
         }
         buffer.reset_uncommitted();
-        assert_eq!(buffer.pos(), 0);
-        assert_eq!(buffer.uncomitted_pages.len(), 1);
-        assert_eq!(buffer.uncomitted_pages.get(0).unwrap().written, 0);
-        println!("commit returning offs={} len={}", offset, uncommitted_len);
         OffsetLen::new(offset as u64, uncommitted_len as u32)
     }
 
-    fn extend(&mut self, buffer: &mut TokenBuffer, by: usize) -> Result<(), ()> {
-        let mut new_uncomitted_page = UncommittedPage::new();
+    fn extend(
+        &mut self,
+        buffer: &mut TokenBuffer,
+        _by: usize,
+    ) -> Result<(), ()> {
         if buffer.pos() > 0 {
-            new_uncomitted_page.unwritten_tail()[..buffer.pos()].copy_from_slice(buffer.written_bytes());
-            new_uncomitted_page.written = buffer.pos();
-            buffer.reset_buffer(new_uncomitted_page.unwritten_tail());
-            buffer.uncomitted_pages.push(new_uncomitted_page);
-            println!("quasi commit of {}", buffer.pos());
+            buffer.extend_uncommitted();
         }
         Ok(())
     }
@@ -245,36 +229,36 @@ impl PageStorage {
         self.token.return_token(token)
     }
 
-    fn persist(&mut self, uncommitted_pages: &Vec<UncommittedPage>) -> Result<(), std::io::Error> {
+    fn persist(
+        &mut self,
+        uncommitted_pages: &Vec<UncommittedPage>,
+    ) -> Result<(), std::io::Error> {
         fn write_pages(pages: &Vec<Page>, file: &mut File) -> io::Result<()> {
             for page in pages {
                 file.write(&page.bytes[..page.written])?;
             }
             Ok(())
         }
-        fn write_uncommitted_pages(pages: &Vec<UncommittedPage>, file: &mut File) -> io::Result<()> {
-            for page in pages {
-                file.write(&page.bytes[..page.written])?;
+        fn write_uncommitted_bytes(
+            pages: &Vec<UncommittedPage>,
+            file: &mut File,
+        ) -> io::Result<()> {
+            for p in pages {
+                file.write(p.written_slice())?;
             }
             Ok(())
         }
-        println!("persist1: data in pages={} data in uncommitted={} data in mmap={}", self.pages_data_len(), PageStorage::uncommitted_pages_data_len(&uncommitted_pages), self.mmap_len());
         let mmap_len = self.mmap_len() as u64;
-        if self.pages_data_len() > 0 || PageStorage::uncommitted_pages_data_len(&uncommitted_pages) > 0 {
+        if self.pages_data_len() > 0 || uncommitted_pages.len() > 0 {
             if let Some(file) = &mut self.file {
-                // println!("seek to {}", mmap_len);
-                file.seek(SeekFrom::Start(mmap_len));
+                file.seek(SeekFrom::Start(mmap_len))?;
                 write_pages(&self.pages, file)?;
-                write_uncommitted_pages(&uncommitted_pages, file)?;
-                // file.seek(SeekFrom::Start(0));
+                write_uncommitted_bytes(uncommitted_pages, file)?;
                 file.flush()?;
                 self.pages.clear();
-                // if self.mmap.is_none() {
-                    self.mmap = Some(unsafe { Mmap::map(&*file)? })
-                // }
+                self.mmap = Some(unsafe { Mmap::map(&*file)? })
             }
         }
-        // println!("persist2: data in pages={} data in uncommitted={} data in mmap={}", self.pages_data_len(), PageStorage::uncommitted_pages_data_len(&uncommitted_pages), self.mmap_len());
         Ok(())
     }
 }
@@ -324,7 +308,6 @@ impl Store for HostStore {
             }
         };
 
-        // let bytes = guard.unwritten_tail();
         TokenBuffer::new_uncommitted(token)
     }
 

--- a/src/storage/host_store.rs
+++ b/src/storage/host_store.rs
@@ -6,18 +6,19 @@
 
 use core::convert::Infallible;
 
-use memmap::Mmap;
+use memmap2::Mmap;
 use parking_lot::RwLock;
 use rkyv::Fallible;
 
 use std::fs::{File, OpenOptions};
-use std::io::{self, Write};
+use std::io::{self, SeekFrom, Write, Seek};
 use std::path::Path;
 use std::sync::Arc;
+use rkyv::ser::Serializer;
 
 use crate::Store;
 
-use super::{OffsetLen, Token, TokenBuffer};
+use super::{OffsetLen, Token, TokenBuffer, UncommittedPage};
 
 const PAGE_SIZE: usize = 1024 * 64;
 
@@ -45,6 +46,15 @@ impl Page {
         Page {
             bytes: Box::new([0u8; PAGE_SIZE]),
             written: 0,
+        }
+    }
+
+    fn create(bytes: &[u8], written: usize) -> Self {
+        let mut b = Box::new([0u8; PAGE_SIZE]);
+        b[..written].copy_from_slice(&bytes[..written]);
+        Page {
+            bytes: b,
+            written,
         }
     }
 
@@ -101,13 +111,19 @@ impl PageStorage {
     }
 
     fn pages_data_len(&self) -> usize {
-        match self.pages.len() {
-            0 => 0,
-            n => {
-                (n - 1) * PAGE_SIZE
-                    + self.pages.last().map(|p| p.slice().len()).unwrap_or(0)
-            }
+        let mut size_sum = 0;
+        for p in &self.pages {
+            size_sum += p.written;
         }
+        size_sum
+    }
+
+    fn uncommitted_pages_data_len(pages: &Vec<UncommittedPage>) -> usize {
+        let mut size_sum = 0;
+        for p in pages {
+            size_sum += p.written;
+        }
+        size_sum
     }
 
     fn offset(&self) -> usize {
@@ -127,15 +143,48 @@ impl PageStorage {
     }
 
     fn get(&self, ofs: &OffsetLen) -> &[u8] {
+        // generalized integer division
+        fn page_for_ofs(pages_ofs: usize, pages: &Vec<Page>) -> usize {
+            assert_ne!(pages.len(), 0);
+            let mut sum = 0;
+            for (i, p) in pages.iter().enumerate() {
+                sum += p.written;
+                if pages_ofs <= sum {
+                    return i
+                }
+            }
+            unreachable!()
+        }
+        // generalized mod
+        fn page_ofs_for_ofs(pages_ofs: usize, pages: &Vec<Page>, cur_page: usize) -> usize {
+            assert!(cur_page < pages.len());
+            if cur_page == 0 {
+                pages_ofs
+            } else {
+                let mut sum = 0;
+                for i in 0..cur_page {
+                    sum += pages[i].written;
+                }
+                pages_ofs - sum
+            }
+        }
+        // println!("get ofs={} len={} number of pages={}", ofs.offset(), ofs.len(), &self.pages.len());
         let OffsetLen(ofs, len) = *ofs;
-        let (ofs, len) = (u64::from(ofs) as usize, u16::from(len) as usize);
+        let (ofs, len) = (u64::from(ofs) as usize, u32::from(len) as usize);
 
         let slice = match &self.mmap {
-            Some(mmap) if ofs <= mmap.len() - len => &mmap[ofs..][..len],
+            Some(mmap) if (ofs + len) <= mmap.len() => {
+     
+                &mmap[ofs..][..len]
+            },
             _ => {
                 let pages_ofs = ofs - self.mmap_len();
-                let cur_page_ofs = pages_ofs % PAGE_SIZE;
-                let cur_page = pages_ofs / PAGE_SIZE;
+                let mut cur_page = page_for_ofs(pages_ofs, &self.pages);
+                let mut cur_page_ofs = page_ofs_for_ofs(pages_ofs, &self.pages, cur_page);
+                if page_for_ofs(pages_ofs, &self.pages) < page_for_ofs(pages_ofs + len, &self.pages) {
+                    cur_page_ofs = 0;
+                    cur_page += 1;
+                }
 
                 &self.pages[cur_page].slice()[cur_page_ofs..][..len]
             }
@@ -144,22 +193,51 @@ impl PageStorage {
     }
 
     fn commit(&mut self, buffer: &mut TokenBuffer) -> OffsetLen {
+        // println!("commit num uncommitted pages={} buffer pos={}", buffer.uncomitted_pages.len(), buffer.pos());
         let offset = self.offset();
-        let len = buffer.advance();
-
-        if let Some(page) = self.pages.last_mut() {
-            page.commit(len)
-        } else {
-            // the token could not have been provided
-            // unless a write-buffer was already allocated
-            unreachable!()
+        let written = buffer.pos();
+        if let Some(top_uncomitted_page) = buffer.uncomitted_pages.last_mut(){
+            top_uncomitted_page.written += written;
         }
-        OffsetLen::new(offset as u64, len as u16)
+        buffer.advance();
+        let mut uncommitted_len = 0;
+        for p in &buffer.uncomitted_pages {
+            uncommitted_len += p.written;
+            // println!("commit written={}", p.written);
+        }
+        if uncommitted_len <= self.unwritten_tail().len() && buffer.uncomitted_pages.len() == 1 {
+            self.unwritten_tail()[..uncommitted_len].copy_from_slice(unsafe { buffer.last_uncommitted_slice(uncommitted_len) });
+            if let Some(top_page) = self.pages.last_mut(){
+                top_page.written += written;
+            }
+        } else {
+            let uncommitted_size = PageStorage::uncommitted_pages_data_len(&buffer.uncomitted_pages);
+            if uncommitted_size < PAGE_SIZE {
+                for p in &buffer.uncomitted_pages {
+                    self.pages.push(Page::create(p.bytes.as_slice(), p.written));
+                }
+            } else {
+                self.persist(&buffer.uncomitted_pages);
+                println!("xcommit persists as uncommitted size is {}", uncommitted_size);
+            }
+        }
+        buffer.reset_uncommitted();
+        assert_eq!(buffer.pos(), 0);
+        assert_eq!(buffer.uncomitted_pages.len(), 1);
+        assert_eq!(buffer.uncomitted_pages.get(0).unwrap().written, 0);
+        println!("commit returning offs={} len={}", offset, uncommitted_len);
+        OffsetLen::new(offset as u64, uncommitted_len as u32)
     }
 
-    fn extend(&mut self, buffer: &mut TokenBuffer) -> Result<(), ()> {
-        self.pages.push(Page::new());
-        buffer.remap(self.unwritten_tail());
+    fn extend(&mut self, buffer: &mut TokenBuffer, by: usize) -> Result<(), ()> {
+        let mut new_uncomitted_page = UncommittedPage::new();
+        if buffer.pos() > 0 {
+            new_uncomitted_page.unwritten_tail()[..buffer.pos()].copy_from_slice(buffer.written_bytes());
+            new_uncomitted_page.written = buffer.pos();
+            buffer.reset_buffer(new_uncomitted_page.unwritten_tail());
+            buffer.uncomitted_pages.push(new_uncomitted_page);
+            println!("quasi commit of {}", buffer.pos());
+        }
         Ok(())
     }
 
@@ -167,22 +245,36 @@ impl PageStorage {
         self.token.return_token(token)
     }
 
-    fn persist(&mut self) -> Result<(), std::io::Error> {
+    fn persist(&mut self, uncommitted_pages: &Vec<UncommittedPage>) -> Result<(), std::io::Error> {
         fn write_pages(pages: &Vec<Page>, file: &mut File) -> io::Result<()> {
             for page in pages {
                 file.write(&page.bytes[..page.written])?;
             }
-            file.flush()
+            Ok(())
         }
-        if self.pages_data_len() > 0 {
+        fn write_uncommitted_pages(pages: &Vec<UncommittedPage>, file: &mut File) -> io::Result<()> {
+            for page in pages {
+                file.write(&page.bytes[..page.written])?;
+            }
+            Ok(())
+        }
+        println!("persist1: data in pages={} data in uncommitted={} data in mmap={}", self.pages_data_len(), PageStorage::uncommitted_pages_data_len(&uncommitted_pages), self.mmap_len());
+        let mmap_len = self.mmap_len() as u64;
+        if self.pages_data_len() > 0 || PageStorage::uncommitted_pages_data_len(&uncommitted_pages) > 0 {
             if let Some(file) = &mut self.file {
+                // println!("seek to {}", mmap_len);
+                file.seek(SeekFrom::Start(mmap_len));
                 write_pages(&self.pages, file)?;
+                write_uncommitted_pages(&uncommitted_pages, file)?;
+                // file.seek(SeekFrom::Start(0));
+                file.flush()?;
                 self.pages.clear();
-                if self.mmap.is_none() {
-                    self.mmap = Some(unsafe { Mmap::map(&file)? })
-                }
+                // if self.mmap.is_none() {
+                    self.mmap = Some(unsafe { Mmap::map(&*file)? })
+                // }
             }
         }
+        // println!("persist2: data in pages={} data in uncommitted={} data in mmap={}", self.pages_data_len(), PageStorage::uncommitted_pages_data_len(&uncommitted_pages), self.mmap_len());
         Ok(())
     }
 }
@@ -232,16 +324,16 @@ impl Store for HostStore {
             }
         };
 
-        let bytes = guard.unwritten_tail();
-        TokenBuffer::new(token, bytes)
+        // let bytes = guard.unwritten_tail();
+        TokenBuffer::new_uncommitted(token)
     }
 
-    fn extend(&self, buffer: &mut TokenBuffer) -> Result<(), ()> {
-        self.inner.write().extend(buffer)
+    fn extend(&self, buffer: &mut TokenBuffer, by: usize) -> Result<(), ()> {
+        self.inner.write().extend(buffer, by)
     }
 
     fn persist(&self) -> Result<(), ()> {
-        self.inner.write().persist().map_err(|_| ())
+        self.inner.write().persist(&vec![]).map_err(|_| ())
     }
 
     fn commit(&self, buf: &mut TokenBuffer) -> Self::Identifier {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -36,11 +36,11 @@ use crate::{
     Debug, Clone, Copy, Archive, Serialize, Deserialize, CheckBytes, Default,
 )]
 #[archive(as = "Self")]
-pub struct OffsetLen(LittleEndian<u64>, LittleEndian<u16>);
+pub struct OffsetLen(LittleEndian<u64>, LittleEndian<u32>);
 
 impl OffsetLen {
     /// Creates an offset with a given value
-    pub fn new<O: Into<LittleEndian<u64>>, L: Into<LittleEndian<u16>>>(
+    pub fn new<O: Into<LittleEndian<u64>>, L: Into<LittleEndian<u32>>>(
         offset: O,
         len: L,
     ) -> OffsetLen {
@@ -58,8 +58,8 @@ impl OffsetLen {
     }
 
     /// The length of the byte representation
-    pub fn len(&self) -> u16 {
-        u16::from(self.1)
+    pub fn len(&self) -> u32 {
+        u32::from(self.1)
     }
 }
 
@@ -188,8 +188,12 @@ pub trait Store {
     /// Commit written bytes to the
     fn commit(&self, buffer: &mut TokenBuffer) -> Self::Identifier;
 
-    /// Request additional bytes for writing    
-    fn extend(&self, buffer: &mut TokenBuffer) -> Result<(), ()>;
+    /// Request additional bytes for writing
+    fn extend(
+        &self,
+        buffer: &mut TokenBuffer,
+        size_needed: usize,
+    ) -> Result<(), ()>;
 
     /// Return the token to the store
     fn return_token(&self, token: Token);

--- a/src/storage/store_ref.rs
+++ b/src/storage/store_ref.rs
@@ -92,8 +92,12 @@ impl<I> StoreRef<I> {
     }
 
     /// Request extra space n the underlying buffer
-    pub fn extend(&self, buffer: &mut TokenBuffer) -> Result<(), ()> {
-        self.inner.extend(buffer)
+    pub fn extend(
+        &self,
+        buffer: &mut TokenBuffer,
+        size_needed: usize,
+    ) -> Result<(), ()> {
+        self.inner.extend(buffer, size_needed)
     }
 
     /// Accept the token back

--- a/src/storage/store_serializer.rs
+++ b/src/storage/store_serializer.rs
@@ -92,9 +92,10 @@ impl<I> Serializer for StoreSerializer<I> {
         loop {
             match self.buffer.write(bytes) {
                 Ok(ok) => return Ok(ok),
-                Err(bo) => {
-                    self.store.extend(&mut self.buffer, bo.size_needed).unwrap()
-                }
+                Err(buffer_overflow) => self
+                    .store
+                    .extend(&mut self.buffer, buffer_overflow.size_needed)
+                    .unwrap(),
             }
         }
     }

--- a/src/storage/store_serializer.rs
+++ b/src/storage/store_serializer.rs
@@ -92,7 +92,9 @@ impl<I> Serializer for StoreSerializer<I> {
         loop {
             match self.buffer.write(bytes) {
                 Ok(ok) => return Ok(ok),
-                Err(_) => self.store.extend(&mut self.buffer).unwrap(),
+                Err(bo) => {
+                    self.store.extend(&mut self.buffer, bo.size_needed).unwrap()
+                }
             }
         }
     }

--- a/tests/host_store_tests.rs
+++ b/tests/host_store_tests.rs
@@ -123,7 +123,6 @@ fn many_raw_persist_and_restore() -> Result<(), io::Error> {
 
 #[test]
 fn big_items_persist_and_restore() -> Result<(), io::Error> {
-
     const SZ: usize = 35176; // size is more than half of the page size
     let item1 = [1u8; SZ];
     let item2 = [2u8; SZ];
@@ -134,15 +133,15 @@ fn big_items_persist_and_restore() -> Result<(), io::Error> {
 
     let host_store = StoreRef::new(HostStore::with_file(dir.path())?);
 
-    let ident1 = host_store.put(&item1 );
-    let ident2 = host_store.put(&item2 );
+    let ident1 = host_store.put(&item1);
+    let ident2 = host_store.put(&item2);
 
     host_store.persist().unwrap();
 
     let host_store_restored = StoreRef::new(HostStore::with_file(dir.path())?);
 
-    let restored1 = host_store_restored.get::<[u8;SZ]>(&ident1);
-    let restored2 = host_store_restored.get::<[u8;SZ]>(&ident2);
+    let restored1 = host_store_restored.get::<[u8; SZ]>(&ident1);
+    let restored2 = host_store_restored.get::<[u8; SZ]>(&ident2);
 
     for b in restored1.into_iter() {
         assert_eq!(*b, 1u8)

--- a/tests/host_store_tests.rs
+++ b/tests/host_store_tests.rs
@@ -120,3 +120,36 @@ fn many_raw_persist_and_restore() -> Result<(), io::Error> {
 
     Ok(())
 }
+
+#[test]
+fn big_items_persist_and_restore() -> Result<(), io::Error> {
+
+    const SZ: usize = 35176; // size is more than half of the page size
+    let item1 = [1u8; SZ];
+    let item2 = [2u8; SZ];
+
+    use tempfile::tempdir;
+
+    let dir = tempdir()?;
+
+    let host_store = StoreRef::new(HostStore::with_file(dir.path())?);
+
+    let ident1 = host_store.put(&item1 );
+    let ident2 = host_store.put(&item2 );
+
+    host_store.persist().unwrap();
+
+    let host_store_restored = StoreRef::new(HostStore::with_file(dir.path())?);
+
+    let restored1 = host_store_restored.get::<[u8;SZ]>(&ident1);
+    let restored2 = host_store_restored.get::<[u8;SZ]>(&ident2);
+
+    for b in restored1.into_iter() {
+        assert_eq!(*b, 1u8)
+    }
+    for b in restored2.into_iter() {
+        assert_eq!(*b, 2u8)
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Storage persistence in Microkelvin following RKYV migration

Resolves issue #116 

Major changes:
- avoids crossing page boundaries, supports uneven page sizes
- on the host side, allows for data objects larger than page size

Limitations:
- on the host side, it will support objects of a predetermined maximum size
