### PR TITLE
VM2 upgrade wasmer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.0] - 2021-07-26
 
+### Removed
+
+- Remove rkyv dependency archive_le feature
+
 ### Added
 
 - Test and fix for objects crossing page boundary

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 rend = { version = "0.3.6", default_features = false }
 parking_lot = { version = "0.11.2", optional = true }
-rkyv = { version = "0.7.29", default_features = false, features = ["size_32", "archive_le", "validation"] }
+rkyv = { version = "0.7.29", default_features = false, features = ["size_32", "validation"] }
 memmap2 = { version = "0.5.3", optional = true }
 bytecheck = { version = "0.6.7", default_features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microkelvin"
-version = "0.16.0-rkyv.2"
+version = "0.16.0-rkyv.3"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 keywords = ["datastructures"]


### PR DESCRIPTION
In order to upgrade rusk-vm wasmer dependency, remove archive_le feature from the rkyv dependency.

Solves rusk-vm issue #351