### PR TITLE
Bump version to `0.17.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2022-10-19
+
 ### Change
 
 - Use `ranno` in lieu of the previous annotations
@@ -225,7 +227,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial
 
-[unreleased]: https://github.com/dusk-network/microkelvin/compare/v0.10.4...HEAD
+[Unreleased]: https://github.com/dusk-network/microkelvin/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/dusk-network/microkelvin/compare/v0.10.4...v0.11.0
 [0.10.4]: https://github.com/dusk-network/microkelvin/compare/v0.10.3...v0.10.4
 [0.10.3]: https://github.com/dusk-network/microkelvin/compare/v0.10.2...v0.10.3
 [0.10.2]: https://github.com/dusk-network/microkelvin/compare/v0.10.2...v0.10.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
     "Kristoffer Ström <kristoffer@dusk.network>",
     "Eduardo Leegwater Simões <eduardo@dusk.network>"
 ]
-version = "0.17.0-rc.0"
+version = "0.17.0"
 
 edition = "2021"
 license = "MPL-2.0"


### PR DESCRIPTION
### Change

- Use `ranno` in lieu of the previous annotations

### Removed

- Remove `Link`
- Remove annotations
- Remove `persistence` feature